### PR TITLE
Added command to docker-compose file to start the db

### DIFF
--- a/src/Core/Models.cs
+++ b/src/Core/Models.cs
@@ -154,7 +154,8 @@ public readonly struct SurrealRestResponse : ISurrealResponse
         AllowTrailingCommas = true,
         ReadCommentHandling = JsonCommentHandling.Skip,
         WriteIndented = false,
-        DefaultIgnoreCondition = JsonIgnoreCondition.Always,
+        // This was throwing an exception when set to JsonIgnoreCondition.Always
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
         DictionaryKeyPolicy = JsonLowerSnakeCaseNamingPolicy.Instance,
         Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
         IgnoreReadOnlyFields = false,

--- a/tests/db/docker-compose.yml
+++ b/tests/db/docker-compose.yml
@@ -5,3 +5,4 @@ services:
     image: surrealdb/surrealdb:latest
     ports:
       - 8082:8000
+    command: start --user root --pass root --log debug memory


### PR DESCRIPTION
Feel free to close this if you feel it isn't necessary.

I wasn't sure if there was a reason to leave the command off of the docker-compose file. Since it's in the test directory I figured it would be better to be able to just `docker-compose up -d` and `docker-compose down` without having to add any `run` parameters in the cli.  

I started looking at the DatabaseTests and found an exception being thrown which was fixed by changing the property in the Models.cs file. I'll keep going on the rest of em. 