### PR TITLE
Fixed Rpc Tests

### DIFF
--- a/src/Core/Database/DbRpc.cs
+++ b/src/Core/Database/DbRpc.cs
@@ -38,7 +38,7 @@ public sealed class DbRpc : ISurrealDatabase<SurrealRpcResponse>
         // TODO: Support jwt auth
         _config.Username = user;
         _config.Password = pass;
-        await Signin(new() {Scope = user, Password = pass}, ct);
+        await Signin(new() {User = user, Pass = pass}, ct);
     }
 
     public async Task Close(CancellationToken ct = default)
@@ -149,11 +149,14 @@ public sealed class DbRpc : ISurrealDatabase<SurrealRpcResponse>
     /// <inheritdoc />
     public async Task<SurrealRpcResponse> Create(SurrealThing thing, object data, CancellationToken ct = default)
     {
-        return await _client.Send(new()
+        var rpcReq = new RpcRequest()
         {
             Method = "create",
+            Async = true,
             Params = new() { thing.ToString(), data }
-        }, ct);
+        };
+        var response = await _client.Send(rpcReq, ct);
+        return response;
     }
 
     /// <inheritdoc />

--- a/src/Core/Models.cs
+++ b/src/Core/Models.cs
@@ -154,7 +154,8 @@ public readonly struct SurrealRestResponse : ISurrealResponse
         AllowTrailingCommas = true,
         ReadCommentHandling = JsonCommentHandling.Skip,
         WriteIndented = false,
-        DefaultIgnoreCondition = JsonIgnoreCondition.Always,
+        // This was throwing an exception when set to JsonIgnoreCondition.Always
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
         DictionaryKeyPolicy = JsonLowerSnakeCaseNamingPolicy.Instance,
         Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
         IgnoreReadOnlyFields = false,
@@ -590,7 +591,7 @@ public sealed class SurrealAuthentication
     [JsonPropertyName("sc")]
     public string? Scope { get; set; }
     [JsonPropertyName("user")]
-    public string? Username { get; set; }
+    public string? User { get; set; }
     [JsonPropertyName("pass")]
-    public string? Password { get; set; }
+    public string? Pass { get; set; }
 }


### PR DESCRIPTION
Rpc expects user/pass and JsonProperty did not work with Rpc.

The error message was a red herring. Turns out during the check to see if you have permissions to create a table if you're not authorized it returns a "table not found" error. 