### PR TITLE
Added round trip tests for both RPC and REST Client

### DIFF
--- a/src/Core/Database/DbRpc.cs
+++ b/src/Core/Database/DbRpc.cs
@@ -129,21 +129,25 @@ public sealed class DbRpc : ISurrealDatabase<SurrealRpcResponse>
     /// <inheritdoc />
     public async Task<SurrealRpcResponse> Query(string sql, IReadOnlyDictionary<string, object?>? vars, CancellationToken ct = default)
     {
-        return await _client.Send(new()
+        var rpcReq = new RpcRequest()
         {
             Method = "query",
             Params = new() { sql, vars }
-        }, ct).ToSurreal();
+        };
+        var response = await _client.Send(rpcReq, ct);
+        return response.ToSurreal();
     }
 
     /// <inheritdoc />
     public async Task<SurrealRpcResponse> Select(SurrealThing thing, CancellationToken ct = default)
     {
-        return await _client.Send(new()
+        var rpcReq = new RpcRequest()
         {
             Method = "select",
             Params = new() { thing.ToString() }
-        }, ct).ToSurreal();
+        };
+        var response = await _client.Send(rpcReq, ct);
+        return response.ToSurreal();
     }
 
     /// <inheritdoc />

--- a/src/Core/Models.cs
+++ b/src/Core/Models.cs
@@ -290,6 +290,13 @@ public enum SurrealResultKind : byte
     Boolean,
 }
 
+public struct SurrealStatus
+{
+    public JsonElement Result { get; set; }
+    public string Status { get; set; }
+    public string Time { get; set; }
+}
+
 /// <summary>
 /// The result of a successful query to the Surreal database.
 /// </summary>
@@ -298,6 +305,19 @@ public readonly struct SurrealResult : IEquatable<SurrealResult>, IComparable<Su
     private readonly JsonElement _json;
     private readonly object? _sentinelOrValue;
     private readonly long _int64ValueField;
+
+    private static readonly JsonSerializerOptions _options = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        AllowTrailingCommas = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        WriteIndented = false,
+        // This was throwing an exception when set to JsonIgnoreCondition.Always
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        IgnoreReadOnlyFields = false,
+        UnknownTypeHandling = JsonUnknownTypeHandling.JsonElement,
+    };
 
 #if SURREAL_NET_INTERNAL
     public
@@ -331,6 +351,49 @@ public readonly struct SurrealResult : IEquatable<SurrealResult>, IComparable<Su
         return GetKind() == SurrealResultKind.Object;
     }
 
+    public bool TryGetObjectCollection<T>(out List<T> document)
+    {
+        // Try to unpack this document
+
+        // Some results come as a simple array of objects
+        // Others come embedded into a 'status' document that can have multiple result sets
+        //[
+        //  {
+        //    "result": [ ... ],
+        //    "status": "OK",
+        //    "time": "71.775µs"
+        //  }
+        //]
+
+        // First see if it the 'embeded status' document type, quick and dirty as a proof of concept
+        var statusDocuments = _json.Deserialize<List<SurrealStatus>>(_options);
+
+        if (statusDocuments != null)
+        {
+            foreach (var statusDocument in statusDocuments)
+            {
+                if (string.IsNullOrEmpty(statusDocument.Status) && string.IsNullOrEmpty(statusDocument.Time))
+                {
+                    break; // This is not a status document
+                }
+
+                // This probably is a status document
+                if (statusDocument.Result.ValueKind == JsonValueKind.Null)
+                {
+                    // Skip over the statuses with no results
+                    // Often from requests that have variables etc
+                    continue;
+                }
+
+                document = statusDocument.Result.Deserialize<List<T>>()!;
+                return GetKind() == SurrealResultKind.Object;
+            }
+        }
+
+        document = _json.Deserialize<List<T>>(_options)!;
+        return GetKind() == SurrealResultKind.Object;
+    }
+    
     public bool TryGetDocument(out string? id, out JsonElement document)
     {
         document = _json;

--- a/tests/Core.Tests/RoundTripTests.cs
+++ b/tests/Core.Tests/RoundTripTests.cs
@@ -1,0 +1,211 @@
+﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions.Extensions;
+using Surreal.Net.Database;
+
+namespace Surreal.Net.Tests
+{
+    public class RpcRoundTripTests : RoundTripTests<DbRpc, SurrealRpcResponse>
+    {
+    }
+    public class RestRoundTripTests : RoundTripTests<DbRest, SurrealRestResponse>
+    {
+    }
+
+    public abstract class RoundTripTests<T, U>
+        where T : ISurrealDatabase<U>, new()
+        where U : ISurrealResponse
+    {
+        protected T Database;
+
+        protected RoundTripTests()
+        {
+            Database = new();
+            Database.Open(ConfigHelper.Default).Wait();
+        }
+
+        [Fact]
+        public async Task CreateRoundTripTest()
+        {
+            var expectedObject = new RoundTripObject();
+
+            var thing = SurrealThing.From("object", Random.Shared.Next().ToString());
+            var response = await Database.Create(thing, expectedObject);
+
+            Assert.NotNull(response);
+            AssertOk(response);
+            Assert.True(response.TryGetResult(out var result));
+            Assert.True(result.TryGetObjectCollection<RoundTripObject>(out var returnedDocument));
+            Assert.Single(returnedDocument);
+            RoundTripObject.AssertAreEqual(expectedObject, returnedDocument.Single());
+        }
+
+        [Fact]
+        public async Task CreateAndSelectRoundTripTest()
+        {
+            var expectedObject = new RoundTripObject();
+
+            var thing = SurrealThing.From("object", Random.Shared.Next().ToString());
+            await Database.Create(thing, expectedObject);
+            var response = await Database.Select(thing);
+
+            Assert.NotNull(response);
+            AssertOk(response);
+            Assert.True(response.TryGetResult(out var result));
+            Assert.True(result.TryGetObjectCollection<RoundTripObject>(out var returnedDocument));
+            Assert.Single(returnedDocument);
+            RoundTripObject.AssertAreEqual(expectedObject, returnedDocument.Single());
+        }
+
+        [Fact]
+        public async Task CreateAndQueryRoundTripTest()
+        {
+            var expectedObject = new RoundTripObject();
+
+            var thing = SurrealThing.From("object", Random.Shared.Next().ToString());
+            await Database.Create(thing, expectedObject);
+            var sql = $"SELECT * FROM \"{thing}\"";
+            var response = await Database.Query(sql, null);
+
+            Assert.NotNull(response);
+            AssertOk(response);
+            Assert.True(response.TryGetResult(out var result));
+            Assert.True(result.TryGetObjectCollection<RoundTripObject>(out var returnedDocument));
+            Assert.Single(returnedDocument);
+            RoundTripObject.AssertAreEqual(expectedObject, returnedDocument.Single());
+        }
+        
+        [Fact]
+        public async Task CreateAndParameterizedQueryRoundTripTest()
+        {
+            var expectedObject = new RoundTripObject();
+
+            var thing = SurrealThing.From("object", Random.Shared.Next().ToString());
+            await Database.Create(thing, expectedObject);
+            var sql = "SELECT * FROM $thing";
+            var param = new Dictionary<string, object?>
+            {
+                ["thing"] = thing,//.ToString(), Needs a ToString() to work
+            };
+            var response = await Database.Query(sql, param);
+
+            Assert.NotNull(response);
+            AssertOk(response);
+            Assert.True(response.TryGetResult(out var result));
+            Assert.True(result.TryGetObjectCollection<RoundTripObject>(out var returnedDocument));
+            Assert.Single(returnedDocument);
+            RoundTripObject.AssertAreEqual(expectedObject, returnedDocument.Single());
+        }
+
+        protected void AssertOk(in ISurrealResponse rpcResponse, [CallerArgumentExpression("rpcResponse")] string caller = "")
+        {
+            if (!rpcResponse.TryGetError(out var err))
+            {
+                return;
+            }
+
+            Exception ex = new($"Expected Ok, got {err.Code} ({err.Message}) in {caller}");
+            throw ex;
+        }
+    }
+
+    public class RoundTripObject
+    {
+        public string String { get; set; } = "A String";
+        //public string MultiLineString { get; set; } = "A\nString"; // Fails to write to DB
+        public string UnicodeString { get; set; } = "A ❤️";
+        public string EmptyString { get; set; } = "";
+        public string NullString { get; set; } = null;
+
+        public int PositiveInteger { get; set; } = int.MaxValue / 2;
+        public int NegativeInteger { get; set; } = int.MinValue / 2;
+        public int ZeroInteger { get; set; } = 0;
+        public int MaxInteger { get; set; } = int.MaxValue;
+        public int MinInteger { get; set; } = int.MinValue;
+
+        public long PositiveLong { get; set; } = long.MaxValue / 2;
+        public long NegativeLong { get; set; } = long.MinValue / 2;
+        public long ZeroLong { get; set; } = 0;
+        public long MaxLong { get; set; } = long.MaxValue;
+        public long MinLong { get; set; } = long.MinValue;
+
+        //public float PositiveFloat { get; set; } = float.MaxValue / 7;
+        //public float NegativeFloat { get; set; } = float.MinValue / 7;
+        //public float ZeroFloat { get; set; } = 0;
+        //public float MaxFloat { get; set; } = float.MaxValue;
+        //public float MinFloat { get; set; } = float.MinValue;
+        //public float NaNFloat { get; set; } = float.NaN; // Not Supported by default by System.Text.Json
+        //public float EpsilonFloat { get; set; } = float.Epsilon;
+        //public float NegEpsilonFloat { get; set; } = -float.Epsilon;
+        //public float PositiveInfinityFloat { get; set; } = float.PositiveInfinity; // Not Supported by default by System.Text.Json
+        //public float NegativeInfinityFloat { get; set; } = float.NegativeInfinity; // Not Supported by default by System.Text.Json
+
+        //public double PositiveDouble { get; set; } = double.MaxValue / 7;
+        //public double NegativeDouble { get; set; } = double.MinValue / 7;
+        //public double ZeroDouble { get; set; } = 0;
+        //public double MaxDouble { get; set; } = double.MaxValue;
+        //public double MinDouble { get; set; } = double.MinValue;
+        //public double NaNDouble { get; set; } = double.NaN; // Not Supported by default by System.Text.Json
+        //public double EpsilonDouble { get; set; } = double.Epsilon;
+        //public double NegEpsilonDouble { get; set; } = -double.Epsilon;
+        //public double PositiveInfinityDouble { get; set; } = double.PositiveInfinity; // Not Supported by default by System.Text.Json
+        //public double NegativeInfinityDouble { get; set; } = double.NegativeInfinity; // Not Supported by default by System.Text.Json
+
+        //public decimal PositiveDecimal { get; set; } = decimal.MaxValue / 7m;
+        //public decimal NegativeDecimal { get; set; } = decimal.MinValue / 7m;
+        //public decimal ZeroDecimal { get; set; } = 0;
+        //public decimal MaxDecimal { get; set; } = decimal.MaxValue;
+        //public decimal MinDecimal { get; set; } = decimal.MinValue;
+
+        //public DateTime MaxUtcDateTime { get; set; } = DateTime.MaxValue.AsUtc(); // This fails to roundtrip, the fractions part of the date gets 00 prepended to it
+        public DateTime MinUtcDateTime { get; set; } = DateTime.MinValue.AsUtc();
+
+        public Guid Guid { get; set; } = Guid.NewGuid();
+        public Guid EmptyGuid { get; set; } = Guid.Empty;
+        
+        public bool TrueBool { get; set; } = true;
+        public bool FalseBool { get; set; } = false;
+
+        public StandardEnum ZeroStandardEnum { get; set; } = StandardEnum.Zero;
+        public StandardEnum OneStandardEnum { get; set; } = StandardEnum.One;
+        public StandardEnum TwoHundredStandardEnum { get; set; } = StandardEnum.TwoHundred;
+        public StandardEnum NegTwoHundredStandardEnum { get; set; } = StandardEnum.NegTwoHundred;
+
+        public FlagsEnum NoneFlagsEnum { get; set; } = FlagsEnum.None;
+        public FlagsEnum AllFlagsEnum { get; set; } = FlagsEnum.All;
+        public FlagsEnum SecondFourthFlagsEnum { get; set; } = FlagsEnum.Second | FlagsEnum.Fourth;
+        public FlagsEnum UndefinedFlagsEnum { get; set; } = (FlagsEnum)(1 << 8);
+        
+        public static void AssertAreEqual(RoundTripObject a, RoundTripObject b)
+        {
+            Assert.NotNull(a);
+            Assert.NotNull(b);
+
+            b.Should().BeEquivalentTo(a);
+        }
+
+        public enum StandardEnum
+        {
+            Zero = 0,
+            One = 1,
+            TwoHundred = 200,
+            NegTwoHundred = -200,
+        }
+
+        [Flags]
+        public enum FlagsEnum
+        {
+            None   = 0,
+            First  = 1 << 0,
+            Second = 1 << 1,
+            Third  = 1 << 2,
+            Fourth = 1 << 3,
+            All = First | Second | Third | Fourth,
+        }
+    }
+}


### PR DESCRIPTION
I have commented out all failing code to help with remediation


I have added `TryGetObjectCollection<T>(out List<T> document)` as a simple shortcut to get the deserialized document. It ended up being far more complicated then required as the `_json` document can come in two shapes.

Perhaps this can be remove in favor of a ORM Implementation?