### PR TITLE
Improved serialization and the unpacking on RPC responses

### DIFF
--- a/src/Driver/Models.cs
+++ b/src/Driver/Models.cs
@@ -427,8 +427,10 @@ public readonly struct SurrealResult : IEquatable<SurrealResult>, IComparable<Su
         if (_json.ValueKind == JsonValueKind.Array) {
             TryGetObjectCollection<T>(out var documents);
             document = documents.FirstOrDefault();
-        } else {
+        } else if (_json.ValueKind == JsonValueKind.Object) {
             document = _json.Deserialize<T>(Constants.JsonOptions);
+        } else {
+            document = default(T);
         }
         return document is not null;
     }

--- a/tests/Driver.Tests/RoundTripTests.cs
+++ b/tests/Driver.Tests/RoundTripTests.cs
@@ -32,9 +32,8 @@ public abstract class RoundTripTests<T, U>
         Assert.NotNull(response);
         AssertOk(response);
         Assert.True(response.TryGetResult(out SurrealResult result));
-        Assert.True(result.TryGetObjectCollection(out List<RoundTripObject>? returnedDocument));
-        Assert.Single(returnedDocument);
-        RoundTripObject.AssertAreEqual(expectedObject, returnedDocument.Single());
+        Assert.True(result.TryGetObject(out RoundTripObject? returnedDocument));
+        RoundTripObject.AssertAreEqual(expectedObject, returnedDocument);
     }
 
     [Fact]
@@ -48,10 +47,8 @@ public abstract class RoundTripTests<T, U>
         Assert.NotNull(response);
         AssertOk(response);
         Assert.True(response.TryGetResult(out SurrealResult result));
-
-        Assert.True(result.TryGetObjectCollection(out List<RoundTripObject>? returnedDocument));
-        Assert.Single(returnedDocument);
-        RoundTripObject.AssertAreEqual(expectedObject, returnedDocument.Single());
+        Assert.True(result.TryGetObject(out RoundTripObject? returnedDocument));
+        RoundTripObject.AssertAreEqual(expectedObject, returnedDocument);
     }
 
     [Fact]
@@ -66,9 +63,8 @@ public abstract class RoundTripTests<T, U>
         Assert.NotNull(response);
         AssertOk(response);
         Assert.True(response.TryGetResult(out SurrealResult result));
-        Assert.True(result.TryGetObjectCollection(out List<RoundTripObject>? returnedDocument));
-        Assert.Single(returnedDocument);
-        RoundTripObject.AssertAreEqual(expectedObject, returnedDocument.Single());
+        Assert.True(result.TryGetObject(out RoundTripObject? returnedDocument));
+        RoundTripObject.AssertAreEqual(expectedObject, returnedDocument);
     }
 
     [Fact]
@@ -87,9 +83,8 @@ public abstract class RoundTripTests<T, U>
         Assert.NotNull(response);
         AssertOk(response);
         Assert.True(response.TryGetResult(out SurrealResult result));
-        Assert.True(result.TryGetObjectCollection(out List<RoundTripObject>? returnedDocument));
-        Assert.Single(returnedDocument);
-        RoundTripObject.AssertAreEqual(expectedObject, returnedDocument.Single());
+        Assert.True(result.TryGetObject(out RoundTripObject? returnedDocument));
+        RoundTripObject.AssertAreEqual(expectedObject, returnedDocument);
     }
 
     protected void AssertOk(


### PR DESCRIPTION
This reverts the complicated serialization.

The RPC response now has that same shape result document that the Rest Document should create. (When #27 goes in)