### PR TITLE
Setting the Accept header when opening the REST client

### DIFF
--- a/src/Driver/Rest/DatabaseRest.cs
+++ b/src/Driver/Rest/DatabaseRest.cs
@@ -54,6 +54,10 @@ public sealed partial class DatabaseRest : IDatabase<RestResponse>, IDisposable 
         // Use database
         SetUse(_config.Database, _config.Namespace);
 
+        // The warp package Surreal uses for HTTP will return a 405
+        // on OSX if the `Accept` header is not set.
+        _client.DefaultRequestHeaders.Add("Accept", new[] { "application/json" });
+
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
When using the REST client to call SurrealDB on OSX the response would always return a 405. It turns out the Warp HTTP lib that Surreal is using was rejecting the request when the `Accept` header was missing. 

