### PR TITLE
Fixed tests on windows not finding the TCP connection

### DIFF
--- a/tests/Shared/SurrealInstance.cs
+++ b/tests/Shared/SurrealInstance.cs
@@ -22,8 +22,10 @@ public static class SurrealInstance {
 
     private static Process? Instantiate(string path) {
         ProcessStartInfo pi = new() {
-            CreateNoWindow = true,
-            UseShellExecute = false,
+            // These two settings can make the tests run twice as fast, but makes it harder to kill rouge DB instances
+            //CreateNoWindow = true,
+            //UseShellExecute = false,
+            UseShellExecute = true,
             FileName = path,
             Arguments = $"start memory -b {TestHelper.Loopback}:{TestHelper.Port} -u {TestHelper.User} -p {TestHelper.Pass} --log debug",
             WorkingDirectory = Environment.CurrentDirectory


### PR DESCRIPTION
Tweaked a few things to make tests work on windows.

There is an issue though if you kill the tests partway though debugging as they are never disposed off. If we can figure out how to always dispose of the DB Instance then we can roughly double the testing speed.