### PR TITLE
Added large document tests to Surreal DB

### DIFF
--- a/tests/Shared/TestHelper.cs
+++ b/tests/Shared/TestHelper.cs
@@ -1,3 +1,5 @@
+using SurrealDB.Common;
+
 using DriverResponse = SurrealDB.Models.Result.DriverResponse;
 
 namespace SurrealDB.Shared.Tests;
@@ -59,4 +61,11 @@ public static class TestHelper {
         Exception ex = new(message);
         throw ex;
     }
+
+    public static string RandomString(int length = 10) {
+        const string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        return new string(Enumerable.Repeat(chars, length)
+           .Select(s => s[ThreadRng.Shared.Next(s.Length)]).ToArray());
+    }
+
 }


### PR DESCRIPTION
**Note:** This PR relies on fixes in ~~#82~~ #95 to work, merge this one after it is completed.

The tests don't currently push past the limit outlined below:

For REST is looks like there is a limit in SurrealDB somewhere between `31238 bytes` and `57862 bytes`.

```
{
    "code": 413,
    "details": "Payload too large",
    "description": "The request has exceeded the maximum payload size. Refer to the documentation for the request limitations."
}
```

For RPC there seems to be a limit somewhere between `17926 bytes` and `31238 bytes`.

```
System.Net.WebSockets.WebSocketException
The remote party closed the WebSocket connection without completing the close handshake.
   at System.Net.WebSockets.ManagedWebSocket.ReceiveAsyncPrivate[TResult](Memory`1 payloadBuffer, CancellationToken cancellationToken)
```