### PR TITLE
Added test case for a Guid that is failing in SurrealDB

### DIFF
--- a/tests/Driver.Tests/Queries/Typed/GuidQueryTests.cs
+++ b/tests/Driver.Tests/Queries/Typed/GuidQueryTests.cs
@@ -16,7 +16,8 @@ public abstract class GuidQueryTests<T> : EqualityQueryTests<T, Guid, Guid>
     private static IEnumerable<Guid> TestValues {
         get {
             yield return Guid.NewGuid();
-            //yield return Guid.Empty; // Re-enable when https://github.com/surrealdb/surrealdb/issues/1364 is fixed
+            yield return Guid.Parse("7909681d-37e5-4373-b868-30fe3430b439");
+            yield return Guid.Empty;
         }
     }
 


### PR DESCRIPTION
Added test case for a Guid that is failing in SurrealDB. This is the cause for the flaky test that was in #95.

Doing a Rest Create (even through postman) for the Guid `7909681d-37e5-4373-b868-30fe3430b439` results in a record being created with the ID of `object:21670y18w5d`.

I have raised it in surrealdb/surrealdb#1364 we can leave this PR open until it is fixed.