### PR TITLE
Fixed failing root auth test

### DIFF
--- a/src/Models/Result/DriverResponse.Enumerator.cs
+++ b/src/Models/Result/DriverResponse.Enumerator.cs
@@ -62,7 +62,7 @@ public readonly partial record struct DriverResponse {
 
         public bool MoveNext() {
             while (_en.MoveNext()) {
-                if (!_en.Current.TryGetError(out ErrorResult err)) {
+                if (!_en.Current.TryGetAnyError(out ErrorResult err)) {
                     continue;
                 }
 

--- a/src/Models/Result/RawResult.cs
+++ b/src/Models/Result/RawResult.cs
@@ -62,6 +62,17 @@ public readonly record struct RawResult {
         err = default;
         return false;
     }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryGetAnyError([NotNullWhen(true)] out ErrorResult err) {
+        if (Wrapped == Kind.Error || Wrapped == Kind.TransportError) {
+            err = new(_time, _status!, _detail);
+            return true;
+        }
+
+        err = default;
+        return false;
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryGetTransportError([NotNullWhen(true)] out TransportErrorResult err) {

--- a/tests/Driver.Tests/Queries/AuthQueryTests.cs
+++ b/tests/Driver.Tests/Queries/AuthQueryTests.cs
@@ -31,9 +31,6 @@ public abstract class AuthQueryTests<T>
             var signinObject = new RootAuth(TestHelper.User, TestHelper.Pass);
             var response = await db.Signin(signinObject);
             TestHelper.AssertOk(response);
-            ResultValue result = response.FirstValue();
-            string? signinJwt = result.GetObject<string>();
-            signinJwt.Should().BeNullOrEmpty();
         }
     );
 

--- a/tests/Driver.Tests/Queries/AuthQueryTests.cs
+++ b/tests/Driver.Tests/Queries/AuthQueryTests.cs
@@ -25,6 +25,8 @@ public abstract class AuthQueryTests<T>
         Logger = logger;
     }
 
+#region Root Auth
+
     [Fact]
     public async Task SignInRootAuthTest() => await DbHandle<T>.WithDatabase(
         async db => {
@@ -33,6 +35,19 @@ public abstract class AuthQueryTests<T>
             TestHelper.AssertOk(response);
         }
     );
+
+    [Fact]
+    public async Task SignInRootAuthErrorTest() => await DbHandle<T>.WithDatabase(
+        async db => {
+            var signinObject = new RootAuth(TestHelper.User, "WrongPassword");
+            var response = await db.Signin(signinObject);
+            TestHelper.AssertError(response);
+        }
+    );
+
+#endregion Root Auth
+
+#region Namespace User Auth
 
     [Fact]
     public async Task SignInNamespaceUserTest() => await DbHandle<T>.WithDatabase(
@@ -113,6 +128,22 @@ public abstract class AuthQueryTests<T>
     );
 
     [Fact]
+    public async Task SignInNamespaceUserErrorTest() => await DbHandle<T>.WithDatabase(
+        async db => {
+            var user = "DatabaseUser";
+            var password = "TestPassword";
+
+            var signinObject = new NamespaceAuth(user, password, TestHelper.Namespace);
+            var signinResponse = await db.Signin(signinObject);
+            TestHelper.AssertError(signinResponse);
+        }
+    );
+    
+#endregion Namespace User Auth
+
+#region Database User Auth
+
+    [Fact]
     public async Task SignInDatabaseUserTest() => await DbHandle<T>.WithDatabase(
         async db => {
             var user = "DatabaseUser";
@@ -191,6 +222,22 @@ public abstract class AuthQueryTests<T>
             await Assert.ThrowsAsync<InvalidOperationException>(async ()=> await db.Query(tokenSql, null));
         }
     );
+
+    [Fact]
+    public async Task SignInDatabaseUserErrorTest() => await DbHandle<T>.WithDatabase(
+        async db => {
+            var user = "DatabaseUser";
+            var password = "TestPassword";
+
+            var signinObject = new DatabaseAuth(user, password, TestHelper.Namespace, TestHelper.Database);
+            var signinResponse = await db.Signin(signinObject);
+            TestHelper.AssertError(signinResponse);
+        }
+    );
+    
+#endregion Database User Auth
+
+#region Scoped User Auth
 
     [Fact]
     public async Task SignUpAndSignInScopedUserTest() => await DbHandle<T>.WithDatabase(
@@ -400,4 +447,19 @@ public abstract class AuthQueryTests<T>
             await Assert.ThrowsAsync<InvalidOperationException>(async ()=> await db.Info());
         }
     );
+
+    [Fact]
+    public async Task SignInScopedUserErrorTest() => await DbHandle<T>.WithDatabase(
+        async db => {
+            var email = "TestUser@example.com";
+            var password = "TestPassword";
+            var scope = "account";
+
+            var signinObject = new ScopeAuth(email, password, TestHelper.Namespace, TestHelper.Database, scope);
+            var signinResponse = await db.Signin(signinObject);
+            TestHelper.AssertError(signinResponse);
+        }
+    );
+
+#endregion Scoped User Auth
 }

--- a/tests/Shared/TestHelper.cs
+++ b/tests/Shared/TestHelper.cs
@@ -55,7 +55,7 @@ public static class TestHelper {
             return;
         }
 
-        var errorResponses = rsp.Errors.ToList();
+        var errorResponses = rsp.Oks.ToList();
         var message = $"Expected Error, got {errorResponses.Count} OK responses in {caller}";
 
         Exception ex = new(message);


### PR DESCRIPTION
Fixed the root auth test that started to fail in the nightly. the response change to it returns `NONE`. I removed the Asserts on the returned data as what it returns is not useful anyway.

Added tests for when Auth fails. Often this will result in a transport error, I added a `TryGetAnyError()` for when you want to check for either a standard or transport error.