### PR TITLE
Added more result tests and made enumeration changes

### DIFF
--- a/src/Models/Result/DriverResponse.Enumerator.cs
+++ b/src/Models/Result/DriverResponse.Enumerator.cs
@@ -62,7 +62,7 @@ public readonly partial record struct DriverResponse {
 
         public bool MoveNext() {
             while (_en.MoveNext()) {
-                if (!_en.Current.TryGetError(out ErrorResult err)) {
+                if (!_en.Current.TryGetAnyError(out ErrorResult err)) {
                     continue;
                 }
 

--- a/src/Models/Result/RawResult.cs
+++ b/src/Models/Result/RawResult.cs
@@ -62,6 +62,17 @@ public readonly record struct RawResult {
         err = default;
         return false;
     }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryGetAnyError([NotNullWhen(true)] out ErrorResult err) {
+        if (Wrapped == Kind.Error || Wrapped == Kind.TransportError) {
+            err = new(_time, _status!, _detail);
+            return true;
+        }
+
+        err = default;
+        return false;
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryGetTransportError([NotNullWhen(true)] out TransportErrorResult err) {

--- a/tests/Driver.Tests/Queries/AuthQueryTests.cs
+++ b/tests/Driver.Tests/Queries/AuthQueryTests.cs
@@ -63,7 +63,7 @@ public abstract class AuthQueryTests<T>
             var signinResponse = await db.Signin(signinObject);
             TestHelper.AssertOk(signinResponse);
             ResultValue result = signinResponse.FirstValue();
-            string? signinJwt = result.GetObject<string>();
+            string? signinJwt = result.AsObject<string>();
             signinJwt.Should().NotBeNullOrEmpty();
 
             var authenticateResponse = await db.Authenticate(signinJwt!);
@@ -73,7 +73,7 @@ public abstract class AuthQueryTests<T>
             var tokenQueryResponse = await db.Query(tokenSql, null);
             TestHelper.AssertOk(tokenQueryResponse);
             ResultValue tokenQueryResult = tokenQueryResponse.FirstValue();
-            Token? token = tokenQueryResult.GetObject<Token>();
+            Token? token = tokenQueryResult.AsObject<Token>();
             token.Should().NotBeNull();
             token.Value.ID.Should().Be(user);
             token.Value.NS.Should().Be(TestHelper.Namespace);
@@ -99,7 +99,7 @@ public abstract class AuthQueryTests<T>
             var signinResponse = await db.Signin(signinObject);
             TestHelper.AssertOk(signinResponse);
             ResultValue result = signinResponse.FirstValue();
-            string? signinJwt = result.GetObject<string>();
+            string? signinJwt = result.AsObject<string>();
             signinJwt.Should().NotBeNullOrEmpty();
 
             var config = TestHelper.Default;
@@ -115,7 +115,7 @@ public abstract class AuthQueryTests<T>
             var tokenQueryResponse = await db.Query(tokenSql, null);
             TestHelper.AssertOk(tokenQueryResponse);
             ResultValue tokenQueryResult = tokenQueryResponse.FirstValue();
-            Token? token = tokenQueryResult.GetObject<Token>();
+            Token? token = tokenQueryResult.AsObject<Token>();
             token.Should().NotBeNull();
             token.Value.ID.Should().Be(user);
             token.Value.NS.Should().Be(TestHelper.Namespace);
@@ -157,7 +157,7 @@ public abstract class AuthQueryTests<T>
             var signinResponse = await db.Signin(signinObject);
             TestHelper.AssertOk(signinResponse);
             ResultValue result = signinResponse.FirstValue();
-            string? signinJwt = result.GetObject<string>();
+            string? signinJwt = result.AsObject<string>();
             signinJwt.Should().NotBeNullOrEmpty();
 
             var authenticateResponse = await db.Authenticate(signinJwt!);
@@ -167,7 +167,7 @@ public abstract class AuthQueryTests<T>
             var tokenQueryResponse = await db.Query(tokenSql, null);
             TestHelper.AssertOk(tokenQueryResponse);
             ResultValue tokenQueryResult = tokenQueryResponse.FirstValue();
-            Token? token = tokenQueryResult.GetObject<Token>();
+            Token? token = tokenQueryResult.AsObject<Token>();
             token.Should().NotBeNull();
             token.Value.ID.Should().Be(user);
             token.Value.NS.Should().Be(TestHelper.Namespace);
@@ -194,7 +194,7 @@ public abstract class AuthQueryTests<T>
             var signinResponse = await db.Signin(signinObject);
             TestHelper.AssertOk(signinResponse);
             ResultValue result = signinResponse.FirstValue();
-            string? signinJwt = result.GetObject<string>();
+            string? signinJwt = result.AsObject<string>();
             signinJwt.Should().NotBeNullOrEmpty();
 
             var config = TestHelper.Default;
@@ -210,7 +210,7 @@ public abstract class AuthQueryTests<T>
             var tokenQueryResponse = await db.Query(tokenSql, null);
             TestHelper.AssertOk(tokenQueryResponse);
             ResultValue tokenQueryResult = tokenQueryResponse.FirstValue();
-            Token? token = tokenQueryResult.GetObject<Token>();
+            Token? token = tokenQueryResult.AsObject<Token>();
             token.Should().NotBeNull();
             token.Value.ID.Should().Be(user);
             token.Value.NS.Should().Be(TestHelper.Namespace);
@@ -262,14 +262,14 @@ public abstract class AuthQueryTests<T>
             var signupResponse = await db.Signup(signupObject);
             TestHelper.AssertOk(signupResponse);
             ResultValue signupResult = signupResponse.FirstValue();
-            string? signupJwt = signupResult.GetObject<string>();
+            string? signupJwt = signupResult.AsObject<string>();
             signupJwt.Should().NotBeNullOrEmpty();
 
             var signinObject = new ScopeAuth(email, password, TestHelper.Namespace, TestHelper.Database, scope);
             var signinResponse = await db.Signin(signinObject);
             TestHelper.AssertOk(signinResponse);
             ResultValue result = signinResponse.FirstValue();
-            string? signinJwt = result.GetObject<string>();
+            string? signinJwt = result.AsObject<string>();
             signinJwt.Should().NotBeNullOrEmpty();
 
             var authenticateResponse = await db.Authenticate(signinJwt!);
@@ -279,7 +279,7 @@ public abstract class AuthQueryTests<T>
             var tokenQueryResponse = await db.Query(tokenSql, null);
             TestHelper.AssertOk(tokenQueryResponse);
             ResultValue tokenQueryResult = tokenQueryResponse.FirstValue();
-            Token? token = tokenQueryResult.GetObject<Token>();
+            Token? token = tokenQueryResult.AsObject<Token>();
             token.Should().NotBeNull();
             token.Value.NS.Should().Be(TestHelper.Namespace);
             token.Value.DB.Should().Be(TestHelper.Database);
@@ -289,7 +289,7 @@ public abstract class AuthQueryTests<T>
             var authQueryResponse = await db.Query(authSql, null);
             TestHelper.AssertOk(authQueryResponse);
             ResultValue authQueryResult = authQueryResponse.FirstValue();
-            User? authUser = authQueryResult.GetObject<User>();
+            User? authUser = authQueryResult.AsObject<User>();
             authUser.Should().NotBeNull();
             authUser.Value.id.Should().Be(token.Value.ID);
             authUser.Value.email.Should().Be(email);
@@ -297,7 +297,7 @@ public abstract class AuthQueryTests<T>
             var infoResponse = await db.Info();
             TestHelper.AssertOk(infoResponse);
             ResultValue infoResult = infoResponse.FirstValue();
-            User? infoUser = infoResult.GetObject<User>();
+            User? infoUser = infoResult.AsObject<User>();
             infoUser.Should().BeEquivalentTo(authUser);
 
             var invalidateResponse = await db.Invalidate();
@@ -332,14 +332,14 @@ public abstract class AuthQueryTests<T>
             var signupResponse = await db.Signup(signupObject);
             TestHelper.AssertOk(signupResponse);
             ResultValue signupResult = signupResponse.FirstValue();
-            string? signupJwt = signupResult.GetObject<string>();
+            string? signupJwt = signupResult.AsObject<string>();
             signupJwt.Should().NotBeNullOrEmpty();
 
             var signinObject = new ScopeAuth(email, password, TestHelper.Namespace, TestHelper.Database, scope);
             var signinResponse = await db.Signin(signinObject);
             TestHelper.AssertOk(signinResponse);
             ResultValue result = signinResponse.FirstValue();
-            string? signinJwt = result.GetObject<string>();
+            string? signinJwt = result.AsObject<string>();
             signinJwt.Should().NotBeNullOrEmpty();
 
             var authenticateResponse = await db.Authenticate(signinJwt!);
@@ -349,7 +349,7 @@ public abstract class AuthQueryTests<T>
             var tokenQueryResponse = await db.Query(tokenSql, null);
             TestHelper.AssertOk(tokenQueryResponse);
             ResultValue tokenQueryResult = tokenQueryResponse.FirstValue();
-            Token? token = tokenQueryResult.GetObject<Token>();
+            Token? token = tokenQueryResult.AsObject<Token>();
             token.Should().NotBeNull();
             token.Value.ID.Should().Be(id);
             token.Value.NS.Should().Be(TestHelper.Namespace);
@@ -360,7 +360,7 @@ public abstract class AuthQueryTests<T>
             var authQueryResponse = await db.Query(authSql, null);
             TestHelper.AssertOk(authQueryResponse);
             ResultValue authQueryResult = authQueryResponse.FirstValue();
-            User? authUser = authQueryResult.GetObject<User>();
+            User? authUser = authQueryResult.AsObject<User>();
             authUser.Should().NotBeNull();
             authUser.Value.id.Should().Be(token.Value.ID);
             authUser.Value.email.Should().Be(email);
@@ -368,7 +368,7 @@ public abstract class AuthQueryTests<T>
             var infoResponse = await db.Info();
             TestHelper.AssertOk(infoResponse);
             ResultValue infoResult = infoResponse.FirstValue();
-            User? infoUser = infoResult.GetObject<User>();
+            User? infoUser = infoResult.AsObject<User>();
             infoUser.Should().BeEquivalentTo(authUser);
 
             var invalidateResponse = await db.Invalidate();
@@ -403,7 +403,7 @@ public abstract class AuthQueryTests<T>
             var signupResponse = await db.Signup(signupObject);
             TestHelper.AssertOk(signupResponse);
             ResultValue signupResult = signupResponse.FirstValue();
-            string? signupJwt = signupResult.GetObject<string>();
+            string? signupJwt = signupResult.AsObject<string>();
             signupJwt.Should().NotBeNullOrEmpty();
 
             var config = TestHelper.Default;
@@ -419,7 +419,7 @@ public abstract class AuthQueryTests<T>
             var tokenQueryResponse = await db.Query(tokenSql, null);
             TestHelper.AssertOk(tokenQueryResponse);
             ResultValue tokenQueryResult = tokenQueryResponse.FirstValue();
-            Token? token = tokenQueryResult.GetObject<Token>();
+            Token? token = tokenQueryResult.AsObject<Token>();
             token.Should().NotBeNull();
             token.Value.NS.Should().Be(TestHelper.Namespace);
             token.Value.DB.Should().Be(TestHelper.Database);
@@ -429,7 +429,7 @@ public abstract class AuthQueryTests<T>
             var authQueryResponse = await db.Query(authSql, null);
             TestHelper.AssertOk(authQueryResponse);
             ResultValue authQueryResult = authQueryResponse.FirstValue();
-            User? authUser = authQueryResult.GetObject<User>();
+            User? authUser = authQueryResult.AsObject<User>();
             authUser.Should().NotBeNull();
             authUser.Value.id.Should().Be(token.Value.ID);
             authUser.Value.email.Should().Be(email);
@@ -437,7 +437,7 @@ public abstract class AuthQueryTests<T>
             var infoResponse = await db.Info();
             TestHelper.AssertOk(infoResponse);
             ResultValue infoResult = infoResponse.FirstValue();
-            User? infoUser = infoResult.GetObject<User>();
+            User? infoUser = infoResult.AsObject<User>();
             infoUser.Should().BeEquivalentTo(authUser);
 
             var invalidateResponse = await db.Invalidate();

--- a/tests/Driver.Tests/Queries/AuthQueryTests.cs
+++ b/tests/Driver.Tests/Queries/AuthQueryTests.cs
@@ -31,9 +31,6 @@ public abstract class AuthQueryTests<T>
             var signinObject = new RootAuth(TestHelper.User, TestHelper.Pass);
             var response = await db.Signin(signinObject);
             TestHelper.AssertOk(response);
-            ResultValue result = response.FirstValue();
-            string? signinJwt = result.GetObject<string>();
-            signinJwt.Should().BeNullOrEmpty();
         }
     );
 

--- a/tests/Driver.Tests/Queries/AuthQueryTests.cs
+++ b/tests/Driver.Tests/Queries/AuthQueryTests.cs
@@ -25,6 +25,8 @@ public abstract class AuthQueryTests<T>
         Logger = logger;
     }
 
+#region Root Auth
+
     [Fact]
     public async Task SignInRootAuthTest() => await DbHandle<T>.WithDatabase(
         async db => {
@@ -33,6 +35,19 @@ public abstract class AuthQueryTests<T>
             TestHelper.AssertOk(response);
         }
     );
+
+    [Fact]
+    public async Task SignInRootAuthErrorTest() => await DbHandle<T>.WithDatabase(
+        async db => {
+            var signinObject = new RootAuth(TestHelper.User, "WrongPassword");
+            var response = await db.Signin(signinObject);
+            TestHelper.AssertError(response);
+        }
+    );
+
+#endregion Root Auth
+
+#region Namespace User Auth
 
     [Fact]
     public async Task SignInNamespaceUserTest() => await DbHandle<T>.WithDatabase(
@@ -113,6 +128,22 @@ public abstract class AuthQueryTests<T>
     );
 
     [Fact]
+    public async Task SignInNamespaceUserErrorTest() => await DbHandle<T>.WithDatabase(
+        async db => {
+            var user = "DatabaseUser";
+            var password = "TestPassword";
+
+            var signinObject = new NamespaceAuth(user, password, TestHelper.Namespace);
+            var signinResponse = await db.Signin(signinObject);
+            TestHelper.AssertError(signinResponse);
+        }
+    );
+    
+#endregion Namespace User Auth
+
+#region Database User Auth
+
+    [Fact]
     public async Task SignInDatabaseUserTest() => await DbHandle<T>.WithDatabase(
         async db => {
             var user = "DatabaseUser";
@@ -191,6 +222,22 @@ public abstract class AuthQueryTests<T>
             await Assert.ThrowsAsync<InvalidOperationException>(async ()=> await db.Query(tokenSql, null));
         }
     );
+
+    [Fact]
+    public async Task SignInDatabaseUserErrorTest() => await DbHandle<T>.WithDatabase(
+        async db => {
+            var user = "DatabaseUser";
+            var password = "TestPassword";
+
+            var signinObject = new DatabaseAuth(user, password, TestHelper.Namespace, TestHelper.Database);
+            var signinResponse = await db.Signin(signinObject);
+            TestHelper.AssertError(signinResponse);
+        }
+    );
+    
+#endregion Database User Auth
+
+#region Scoped User Auth
 
     [Fact]
     public async Task SignUpAndSignInScopedUserTest() => await DbHandle<T>.WithDatabase(
@@ -400,4 +447,19 @@ public abstract class AuthQueryTests<T>
             await Assert.ThrowsAsync<InvalidOperationException>(async ()=> await db.Info());
         }
     );
+
+    [Fact]
+    public async Task SignInScopedUserErrorTest() => await DbHandle<T>.WithDatabase(
+        async db => {
+            var email = "TestUser@example.com";
+            var password = "TestPassword";
+            var scope = "account";
+
+            var signinObject = new ScopeAuth(email, password, TestHelper.Namespace, TestHelper.Database, scope);
+            var signinResponse = await db.Signin(signinObject);
+            TestHelper.AssertError(signinResponse);
+        }
+    );
+
+#endregion Scoped User Auth
 }

--- a/tests/Driver.Tests/Queries/EqualityQueryTests.cs
+++ b/tests/Driver.Tests/Queries/EqualityQueryTests.cs
@@ -18,7 +18,7 @@ public abstract class EqualityQueryTests<T, TKey, TValue> : QueryTests<T, TKey, 
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            var resultValue = result.GetObject<bool>();
+            var resultValue = result.AsObject<bool>();
             resultValue.Should().Be(expectedResult);
         }
     );
@@ -36,7 +36,7 @@ public abstract class EqualityQueryTests<T, TKey, TValue> : QueryTests<T, TKey, 
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            var resultValue = result.GetObject<bool>();
+            var resultValue = result.AsObject<bool>();
             resultValue.Should().Be(expectedResult);
         }
     );

--- a/tests/Driver.Tests/Queries/GeneralQueryTests.cs
+++ b/tests/Driver.Tests/Queries/GeneralQueryTests.cs
@@ -115,23 +115,8 @@ public abstract class GeneralQueryTests<T>
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            DateTime? doc = result.GetObject<DateTime>();
+            DateTime? doc = result.AsObject<DateTime>();
             doc.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(10));
-        }
-    );
-
-    [Fact]
-    public async Task SimpleArrayResultQueryTest() => await DbHandle<T>.WithDatabase(
-        async db => {
-            List<int> expectedObject = new() { 1, 2, 3 };
-            string sql = "SELECT * FROM [1, 2, 3]";
-
-            var response = await db.Query(sql, null);
-
-            TestHelper.AssertOk(response);
-            ResultValue result = response.FirstValue();
-            List<int>? doc = result.GetObject<List<int>>();
-            doc.Should().Equal(expectedObject);
         }
     );
 
@@ -145,7 +130,7 @@ public abstract class GeneralQueryTests<T>
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            List<OldVehicleResponse>? doc = result.GetObject<List<OldVehicleResponse>>();
+            List<OldVehicleResponse>? doc = result.AsObject<List<OldVehicleResponse>>();
             doc.Should().BeEquivalentTo(expectedObject);
         }
     );
@@ -162,7 +147,7 @@ public abstract class GeneralQueryTests<T>
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            List<VehicleTypeResult>? doc = result.GetObject<List<VehicleTypeResult>>();
+            List<VehicleTypeResult>? doc = result.AsObject<List<VehicleTypeResult>>();
             doc.Should().BeEquivalentTo(expectedObject);
         }
     );
@@ -177,7 +162,7 @@ public abstract class GeneralQueryTests<T>
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            List<FlatWheelResult>? doc = result.GetObject<List<FlatWheelResult>>();
+            List<FlatWheelResult>? doc = result.AsObject<List<FlatWheelResult>>();
             doc.Should().BeEquivalentTo(expectedObject);
         }
     );
@@ -195,7 +180,7 @@ GROUP BY RegisteredCountry;";
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            List<GroupedCountries>? doc = result.GetObject<List<GroupedCountries>>();
+            List<GroupedCountries>? doc = result.AsObject<List<GroupedCountries>>();
             doc.Should().HaveCount(2);
         }
     );
@@ -209,7 +194,7 @@ GROUP BY RegisteredCountry;";
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            string? doc = result.GetObject<string>();
+            string? doc = result.AsObject<string>();
             doc.Should().BeEquivalentTo("4768b3fc7ac751e03a614e2349abf3bf");
         }
     );
@@ -228,7 +213,7 @@ GROUP BY RegisteredCountry;";
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            MathResultDocument? doc = result.GetObject<MathResultDocument>();
+            MathResultDocument? doc = result.AsObject<MathResultDocument>();
             doc.Should().BeEquivalentTo(expectedResult);
         }
     );
@@ -248,7 +233,7 @@ GROUP BY RegisteredCountry;";
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            MathResultDocument? doc = result.GetObject<MathResultDocument>();
+            MathResultDocument? doc = result.AsObject<MathResultDocument>();
             doc.Should().NotBeNull();
             doc!.result.Should().BeApproximately(expectedResult.result, 0.000001f);
         }
@@ -269,7 +254,7 @@ GROUP BY RegisteredCountry;";
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            MathResultDocument? doc = result.GetObject<MathResultDocument>();
+            MathResultDocument? doc = result.AsObject<MathResultDocument>();
             doc.Should().NotBeNull();
             doc!.result.Should().BeApproximately(expectedResult.result, 0.001f);
         }
@@ -290,7 +275,7 @@ GROUP BY RegisteredCountry;";
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            MathResultDocument? doc = result.GetObject<MathResultDocument>();
+            MathResultDocument? doc = result.AsObject<MathResultDocument>();
             doc.Should().BeEquivalentTo(expectedResult);
         }
     );
@@ -305,7 +290,7 @@ GROUP BY RegisteredCountry;";
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            string? doc = result.GetObject<string>();
+            string? doc = result.AsObject<string>();
             doc.Should().NotBeNull();
             doc.Should().Be(expectedResult);
         }
@@ -346,7 +331,7 @@ GROUP BY RegisteredCountry;";
     private static void AssertResponse(DriverResponse response, TestObject<int, int> expectedResult) {
         TestHelper.AssertOk(response);
         Assert.True(response!.TryGetFirstValue(out ResultValue result));
-        TestObject<int, int>? doc = result.GetObject<TestObject<int, int>>();
+        TestObject<int, int>? doc = result.AsObject<TestObject<int, int>>();
         doc.Should().BeEquivalentTo(expectedResult);
     }
 }

--- a/tests/Driver.Tests/Queries/InequalityQueryTests.cs
+++ b/tests/Driver.Tests/Queries/InequalityQueryTests.cs
@@ -18,7 +18,7 @@ public abstract class InequalityQueryTests<T, TKey, TValue> : EqualityQueryTests
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            var resultValue = result.GetObject<bool>();
+            var resultValue = result.AsObject<bool>();
             resultValue.Should().Be(expectedResult);
         }
     );
@@ -36,7 +36,7 @@ public abstract class InequalityQueryTests<T, TKey, TValue> : EqualityQueryTests
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            var resultValue = result.GetObject<bool>();
+            var resultValue = result.AsObject<bool>();
             resultValue.Should().Be(expectedResult);
         }
     );
@@ -54,7 +54,7 @@ public abstract class InequalityQueryTests<T, TKey, TValue> : EqualityQueryTests
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            var resultValue = result.GetObject<bool>();
+            var resultValue = result.AsObject<bool>();
             resultValue.Should().Be(expectedResult);
         }
     );
@@ -72,7 +72,7 @@ public abstract class InequalityQueryTests<T, TKey, TValue> : EqualityQueryTests
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            var resultValue = result.GetObject<bool>();
+            var resultValue = result.AsObject<bool>();
             resultValue.Should().Be(expectedResult);
         }
     );

--- a/tests/Driver.Tests/Queries/ManagementQueryTests.cs
+++ b/tests/Driver.Tests/Queries/ManagementQueryTests.cs
@@ -68,7 +68,7 @@ public abstract class ManagementQueryTests<T>
 
                 TestHelper.AssertOk(response);
                 ResultValue result = response.FirstValue();
-                TestObject<int, string>? doc = result.GetObject<TestObject<int, string>>();
+                TestObject<int, string>? doc = result.AsObject<TestObject<int, string>>();
                 doc.Should().BeEquivalentTo(expectedOtherObject);
             }
 
@@ -80,7 +80,7 @@ public abstract class ManagementQueryTests<T>
 
                 TestHelper.AssertOk(response);
                 ResultValue result = response.FirstValue();
-                TestObject<int, string>? doc = result.GetObject<TestObject<int, string>>();
+                TestObject<int, string>? doc = result.AsObject<TestObject<int, string>>();
                 doc.Should().BeEquivalentTo(expectedOriginalObject);
             }
 
@@ -110,7 +110,7 @@ public abstract class ManagementQueryTests<T>
 
                 TestHelper.AssertOk(response);
                 ResultValue result = response.FirstValue();
-                TestObject<int, string>? doc = result.GetObject<TestObject<int, string>>();
+                TestObject<int, string>? doc = result.AsObject<TestObject<int, string>>();
                 doc.Should().BeEquivalentTo(expectedOtherObject);
             }
 
@@ -122,7 +122,7 @@ public abstract class ManagementQueryTests<T>
 
                 TestHelper.AssertOk(response);
                 ResultValue result = response.FirstValue();
-                TestObject<int, string>? doc = result.GetObject<TestObject<int, string>>();
+                TestObject<int, string>? doc = result.AsObject<TestObject<int, string>>();
                 doc.Should().BeEquivalentTo(expectedOriginalObject);
             }
 

--- a/tests/Driver.Tests/Queries/MathQueryTests.cs
+++ b/tests/Driver.Tests/Queries/MathQueryTests.cs
@@ -23,7 +23,7 @@ public abstract class MathQueryTests<T, TKey, TValue> : InequalityQueryTests<T, 
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            var resultValue = result.GetObject<TValue>();
+            var resultValue = result.AsObject<TValue>();
             AssertEquivalency(resultValue, expectedResult);
         }
     );
@@ -41,7 +41,7 @@ public abstract class MathQueryTests<T, TKey, TValue> : InequalityQueryTests<T, 
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            var value = result.GetObject<TValue>();
+            var value = result.AsObject<TValue>();
             AssertEquivalency(value, expectedResult);
         }
     );
@@ -59,7 +59,7 @@ public abstract class MathQueryTests<T, TKey, TValue> : InequalityQueryTests<T, 
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            var value = result.GetObject<TValue>();
+            var value = result.AsObject<TValue>();
             AssertEquivalency(value, expectedResult);
         }
     );
@@ -92,7 +92,7 @@ public abstract class MathQueryTests<T, TKey, TValue> : InequalityQueryTests<T, 
             ResultValue result = response.FirstValue();
 
             if (!divisorIsZero) {
-                var value = result.GetObject<TValue>();
+                var value = result.AsObject<TValue>();
                 AssertEquivalency(value, expectedResult);
             } else {
                 Assert.True(false); // TODO: Test for the expected result when doing a divide by zero

--- a/tests/Driver.Tests/Queries/QueryTests.cs
+++ b/tests/Driver.Tests/Queries/QueryTests.cs
@@ -23,7 +23,7 @@ public abstract class QueryTests<T, TKey, TValue>
             var response = await db.Create(thing, expectedObject);
 
             ResultValue result = response.FirstValue();
-            TestObject<TKey, TValue>? doc = result.GetObject<TestObject<TKey, TValue>>();
+            TestObject<TKey, TValue>? doc = result.AsObject<TestObject<TKey, TValue>>();
             doc.Should().BeEquivalentTo(expectedObject);
         }
     );
@@ -40,7 +40,7 @@ public abstract class QueryTests<T, TKey, TValue>
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            TestObject<TKey, TValue>? doc = result.GetObject<TestObject<TKey, TValue>>();
+            TestObject<TKey, TValue>? doc = result.AsObject<TestObject<TKey, TValue>>();
             doc.Should().BeEquivalentTo(expectedObject);
         }
     );
@@ -78,7 +78,7 @@ public abstract class QueryTests<T, TKey, TValue>
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            TestObject<TKey, TValue>? doc = result.GetObject<TestObject<TKey, TValue>>();
+            TestObject<TKey, TValue>? doc = result.AsObject<TestObject<TKey, TValue>>();
             doc.Should().BeEquivalentTo(expectedObject);
         }
     );
@@ -102,7 +102,7 @@ public abstract class QueryTests<T, TKey, TValue>
             var response = await db.Select(thing);
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            TestObject<TKey, TValue>? doc = result.GetObject<ExtendedTestObject<TKey, TValue>>();
+            TestObject<TKey, TValue>? doc = result.AsObject<ExtendedTestObject<TKey, TValue>>();
             doc.Should().BeEquivalentTo(expectedObject);
         }
     );
@@ -118,7 +118,7 @@ public abstract class QueryTests<T, TKey, TValue>
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            TValue? doc = result.GetObject<TValue>();
+            TValue? doc = result.AsObject<TValue>();
             doc.Should().BeEquivalentTo(val1);
         }
     );
@@ -136,7 +136,7 @@ public abstract class QueryTests<T, TKey, TValue>
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            TestObject<TKey, TValue>? doc = result.GetObject<ExtendedTestObject<TKey, TValue>>();
+            TestObject<TKey, TValue>? doc = result.AsObject<ExtendedTestObject<TKey, TValue>>();
             doc.Should().BeEquivalentTo(expectedObject);
         }
     );
@@ -156,7 +156,7 @@ public abstract class QueryTests<T, TKey, TValue>
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            TestObject<TKey, TValue>? doc = result.GetObject<TestObject<TKey, TValue>>();
+            TestObject<TKey, TValue>? doc = result.AsObject<TestObject<TKey, TValue>>();
             doc.Should().BeEquivalentTo(expectedObject);
         }
     );
@@ -177,7 +177,7 @@ public abstract class QueryTests<T, TKey, TValue>
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            TestObject<TKey, TValue>? doc = result.GetObject<TestObject<TKey, TValue>>();
+            TestObject<TKey, TValue>? doc = result.AsObject<TestObject<TKey, TValue>>();
             doc.Should().BeEquivalentTo(expectedObject);
         }
     );
@@ -200,7 +200,7 @@ public abstract class QueryTests<T, TKey, TValue>
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            TestObject<TKey, TValue>? doc = result.GetObject<TestObject<TKey, TValue>>();
+            TestObject<TKey, TValue>? doc = result.AsObject<TestObject<TKey, TValue>>();
             Logger.WriteLine("out: {0}", Serialize(doc));
             doc.Should().BeEquivalentTo(expectedObject);
         }
@@ -230,7 +230,7 @@ public abstract class QueryTests<T, TKey, TValue>
             var thing2Response = await db.Query(thing2Sql, vars);
             TestHelper.AssertOk(thing2Response);
             ResultValue thing2Result = thing2Response.FirstValue();
-            Field<TestObject<TKey, TValue>>? thing2Doc = thing2Result.GetObject<Field<TestObject<TKey, TValue>>>();
+            Field<TestObject<TKey, TValue>>? thing2Doc = thing2Result.AsObject<Field<TestObject<TKey, TValue>>>();
             thing2Doc.Should().NotBeNull();
             thing2Doc!.field.First().Should().BeEquivalentTo(expectedObject);
         }

--- a/tests/Driver.Tests/ResultTests.cs
+++ b/tests/Driver.Tests/ResultTests.cs
@@ -181,7 +181,7 @@ public abstract class ResultTests<T>
             result.TryGetValue(out float _).Should().BeFalse();
             result.TryGetValue(out double _).Should().BeFalse();
             result.TryGetValue(out bool _).Should().BeFalse();
-            result.AsEnumerable<object>().Should().BeEmpty();
+            result.AsEnumerable<object>().First().Should().Be(null);
             result.AsObject<object>().Should().BeNull();
         }
     );

--- a/tests/Driver.Tests/ResultTests.cs
+++ b/tests/Driver.Tests/ResultTests.cs
@@ -26,6 +26,8 @@ public abstract class ResultTests<T>
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
+            result.IsNullOrUndefined.Should().BeFalse();
+            result.IsEmpty.Should().BeFalse();
             result.TryGetValue(out int value).Should().BeTrue();
             value.Should().Be(expectedValue);
         }
@@ -45,6 +47,28 @@ public abstract class ResultTests<T>
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
+            result.IsNullOrUndefined.Should().BeFalse();
+            result.IsEmpty.Should().BeFalse();
+            result.TryGetValue(out long value).Should().BeTrue();
+            value.Should().Be(expectedValue);
+        }
+    );
+
+    [Theory]
+    [InlineData((ulong)1)]
+    [InlineData((long)0)]
+    [InlineData(long.MaxValue)]
+    [InlineData(long.MinValue)]
+    public async Task ULongTryGetValueQueryTest(long expectedValue) => await DbHandle<T>.WithDatabase(
+        async db => {
+            string sql = "select * from <int>($value)";
+            Dictionary<string, object?> param = new() { ["value"] = expectedValue };
+            var response = await db.Query(sql, param);
+
+            TestHelper.AssertOk(response);
+            ResultValue result = response.FirstValue();
+            result.IsNullOrUndefined.Should().BeFalse();
+            result.IsEmpty.Should().BeFalse();
             result.TryGetValue(out long value).Should().BeTrue();
             value.Should().Be(expectedValue);
         }
@@ -70,6 +94,8 @@ public abstract class ResultTests<T>
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
+            result.IsNullOrUndefined.Should().BeFalse();
+            result.IsEmpty.Should().BeFalse();
             result.TryGetValue(out float value).Should().BeTrue();
             value.Should().Be(expectedValue);
         }
@@ -95,6 +121,8 @@ public abstract class ResultTests<T>
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
+            result.IsNullOrUndefined.Should().BeFalse();
+            result.IsEmpty.Should().BeFalse();
             result.TryGetValue(out double value).Should().BeTrue();
             value.Should().Be(expectedValue);
         }
@@ -111,8 +139,51 @@ public abstract class ResultTests<T>
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
+            result.IsNullOrUndefined.Should().BeFalse();
+            result.IsEmpty.Should().BeFalse();
             result.TryGetValue(out bool value).Should().BeTrue();
             value.Should().Be(expectedValue);
+        }
+    );
+
+    [Theory]
+    [InlineData(new int[] { 1, 2, 3 })]
+    [InlineData(new int[] { 1 })]
+    [InlineData(new int[] { })]
+    public async Task AsEnumerableQueryTest(int[] expectedValue) => await DbHandle<T>.WithDatabase(
+        async db => {
+            string sql = "select * from $value";
+            Dictionary<string, object?> param = new() { ["value"] = expectedValue };
+            var response = await db.Query(sql, param);
+
+            TestHelper.AssertOk(response);
+            ResultValue result = response.FirstValue();
+            result.IsEmpty.Should().Be(!expectedValue.Any());
+            result.IsNullOrUndefined.Should().BeFalse();
+            var items = result.AsEnumerable<int>();
+            items.Should().NotBeNull();
+            items.Should().BeEquivalentTo(expectedValue);
+        }
+    );
+
+    [Fact]
+    public async Task NullResultQueryTest() => await DbHandle<T>.WithDatabase(
+        async db => {
+            string sql = "select * from NONE";
+            var response = await db.Query(sql);
+            
+            TestHelper.AssertOk(response);
+            ResultValue result = response.FirstValue();
+            result.IsNullOrUndefined.Should().BeTrue();
+            //result.IsEmpty.Should().BeTrue(); // Not sure if it should be empty or not. This query returns a array of [null]
+
+            result.TryGetValue(out int _).Should().BeFalse();
+            result.TryGetValue(out long _).Should().BeFalse();
+            result.TryGetValue(out float _).Should().BeFalse();
+            result.TryGetValue(out double _).Should().BeFalse();
+            result.TryGetValue(out bool _).Should().BeFalse();
+            result.AsEnumerable<object>().Should().BeEmpty();
+            result.AsObject<object>().Should().BeNull();
         }
     );
 }

--- a/tests/Driver.Tests/ResultTests.cs
+++ b/tests/Driver.Tests/ResultTests.cs
@@ -161,7 +161,6 @@ public abstract class ResultTests<T>
             result.IsEmpty.Should().Be(!expectedValue.Any());
             result.IsNullOrUndefined.Should().BeFalse();
             var items = result.AsEnumerable<int>();
-            items.Should().NotBeNull();
             items.Should().BeEquivalentTo(expectedValue);
         }
     );
@@ -171,7 +170,7 @@ public abstract class ResultTests<T>
         async db => {
             string sql = "select * from NONE";
             var response = await db.Query(sql);
-            
+
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
             result.IsNullOrUndefined.Should().BeTrue();

--- a/tests/Driver.Tests/Roundtrip/RoundTripTests.cs
+++ b/tests/Driver.Tests/Roundtrip/RoundTripTests.cs
@@ -58,7 +58,7 @@ public abstract class RoundTripTests<T>
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            var returnedDocument = result.GetObject<RoundTripObject>();
+            var returnedDocument = result.AsObject<RoundTripObject>();
             RoundTripObject.AssertAreEqual(document, returnedDocument);
         }
     );
@@ -75,7 +75,7 @@ public abstract class RoundTripTests<T>
 
             TestHelper.AssertOk(response);
             ResultValue result = response.FirstValue();
-            var returnedDocument = result.GetObject<RoundTripObject>();
+            var returnedDocument = result.AsObject<RoundTripObject>();
             RoundTripObject.AssertAreEqual(document, returnedDocument);
         }
     );
@@ -94,7 +94,7 @@ public abstract class RoundTripTests<T>
             response.Should().NotBeNull();
             TestHelper.AssertOk(response);
             response.TryGetFirstValue(out ResultValue result).Should().BeTrue();
-            var returnedDocument = result.GetObject<RoundTripObject>();
+            var returnedDocument = result.AsObject<RoundTripObject>();
             RoundTripObject.AssertAreEqual(document, returnedDocument);
         }
     );
@@ -114,7 +114,7 @@ public abstract class RoundTripTests<T>
 
         TestHelper.AssertOk(response);
         ResultValue result = response.FirstValue();
-        var returnedDocument = result.GetObject<RoundTripObject>();
+        var returnedDocument = result.AsObject<RoundTripObject>();
         RoundTripObject.AssertAreEqual(document, returnedDocument);
     });
 }

--- a/tests/Shared/TestHelper.cs
+++ b/tests/Shared/TestHelper.cs
@@ -55,7 +55,7 @@ public static class TestHelper {
             return;
         }
 
-        var errorResponses = rsp.Errors.ToList();
+        var errorResponses = rsp.Oks.ToList();
         var message = $"Expected Error, got {errorResponses.Count} OK responses in {caller}";
 
         Exception ex = new(message);


### PR DESCRIPTION
**Note:** this PR has includes the fixes from the nightly changes in #102, merge that first.

I changed the name of the following methods.
`GetObject<T>()` to `AsObject<T>()`
`GetArray<T>()` to `AsEnumerable<T>()`

I'm not too sure about `AsObject`, feel free to change if you can think of a more suitable name.

`AsObject<T>()` is meant to be used when you know you will only get a single item back.
`AsEnumerable<T>()` Should be used any other time.

Currently doing `AsObject<List<int>>()` will only work when there is more than one item in the result array. A single returned int is unpacked into a standalone `int` value and therefore cannot be deserialized.