### PR TITLE
Added test for retrieving large documents

### DIFF
--- a/src/Common/WsStream.cs
+++ b/src/Common/WsStream.cs
@@ -13,7 +13,7 @@ public sealed class WsStream : Stream {
     private int _prefixConsumed;
 
     private readonly WebSocket _ws;
-    private bool endOfMessage = false;
+    public bool EndOfMessage { get; private set; } = false;
 
     public override bool CanRead => true;
     public override bool CanSeek => false;
@@ -89,12 +89,11 @@ public sealed class WsStream : Stream {
         }
 
         int read = 0;
-        while (!buffer.IsEmpty && !endOfMessage) {
+        if (!EndOfMessage) {
             ValueWebSocketReceiveResult rsp = await _ws.ReceiveAsync(buffer, cancellationToken);
-            buffer = buffer.Slice(rsp.Count);
-            read += rsp.Count;
+            read = rsp.Count;
 
-            endOfMessage = rsp.EndOfMessage;
+            EndOfMessage = rsp.EndOfMessage;
         }
 
         return read;

--- a/src/Ws/Ws.cs
+++ b/src/Ws/Ws.cs
@@ -2,6 +2,8 @@ using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
+using SurrealDB.Common;
+
 namespace SurrealDB.Ws;
 
 public sealed class Ws : IDisposable, IAsyncDisposable {
@@ -84,6 +86,12 @@ public sealed class Ws : IDisposable, IAsyncDisposable {
             if (!handler.Persistent) {
                 // persistent handlers are for notifications and are not removed automatically
                 Unregister(handler);
+            }
+
+            if (stream is WsStream wsStream) {
+                while (!wsStream.EndOfMessage) {
+                    await Task.Delay(13, stoppingToken);
+                }
             }
         }
     }

--- a/tests/Driver.Tests/Roundtrip/RoundTripTests.cs
+++ b/tests/Driver.Tests/Roundtrip/RoundTripTests.cs
@@ -30,7 +30,7 @@ public abstract class RoundTripTests<T>
         get {
             //yield return new RoundTripObject();
 
-            for (int i = 8; i < 9; i++) {
+            for (int i = 4; i < 9; i++) {
                 var arraySize = 2 << i;
                 var largeDocument = new RoundTripObject {
                     StringArray = new string[arraySize],

--- a/tests/Driver.Tests/Roundtrip/RoundTripTests.cs
+++ b/tests/Driver.Tests/Roundtrip/RoundTripTests.cs
@@ -117,6 +117,31 @@ public abstract class RoundTripTests<T>
         var returnedDocument = result.AsObject<RoundTripObject>();
         RoundTripObject.AssertAreEqual(document, returnedDocument);
     });
+    
+    [Theory]
+    [MemberData(nameof(Documents))]
+    public async Task CreateManyAndQueryRoundTripTest(RoundTripObject document) => await DbHandle<T>.WithDatabase(
+        async db => {
+            var count = 1;//10;
+            Logger.WriteLine("Document size in bytes: {0} x {1}", JsonSerializer.Serialize(document, SerializerOptions.Shared).Length * sizeof(char), count);
+
+            for (int i = 0; i < count; i++) {
+                Thing thing = new("object", ThreadRng.Shared.Next());
+                await db.Create(thing, document);
+            }
+
+            string sql = "SELECT * FROM object";
+            var response = await db.Query(sql, null);
+
+            response.Should().NotBeNull();
+            TestHelper.AssertOk(response);
+            response.TryGetFirstValue(out ResultValue result).Should().BeTrue();
+            var returnedDocuments = result.AsEnumerable<RoundTripObject>();
+            foreach (var returnedDocument in returnedDocuments) {
+                RoundTripObject.AssertAreEqual(document, returnedDocument);
+            }
+        }
+    );
 }
 
 public class RoundTripObject {

--- a/tests/Driver.Tests/Roundtrip/RoundTripTests.cs
+++ b/tests/Driver.Tests/Roundtrip/RoundTripTests.cs
@@ -28,9 +28,9 @@ public abstract class RoundTripTests<T>
 
     private static IEnumerable<RoundTripObject> DocumentsToTest {
         get {
-            yield return new RoundTripObject();
+            //yield return new RoundTripObject();
 
-            for (int i = 4; i < 9; i++) {
+            for (int i = 8; i < 9; i++) {
                 var arraySize = 2 << i;
                 var largeDocument = new RoundTripObject {
                     StringArray = new string[arraySize],
@@ -122,7 +122,7 @@ public abstract class RoundTripTests<T>
     [MemberData(nameof(Documents))]
     public async Task CreateManyAndQueryRoundTripTest(RoundTripObject document) => await DbHandle<T>.WithDatabase(
         async db => {
-            var count = 1;//10;
+            var count = 10;
             Logger.WriteLine("Document size in bytes: {0} x {1}", JsonSerializer.Serialize(document, SerializerOptions.Shared).Length * sizeof(char), count);
 
             for (int i = 0; i < count; i++) {
@@ -136,7 +136,8 @@ public abstract class RoundTripTests<T>
             response.Should().NotBeNull();
             TestHelper.AssertOk(response);
             response.TryGetFirstValue(out ResultValue result).Should().BeTrue();
-            var returnedDocuments = result.AsEnumerable<RoundTripObject>();
+            var returnedDocuments = result.AsEnumerable<RoundTripObject>().ToList();
+            returnedDocuments.Count.Should().Be(count);
             foreach (var returnedDocument in returnedDocuments) {
                 RoundTripObject.AssertAreEqual(document, returnedDocument);
             }


### PR DESCRIPTION
**Note:** this PR make use of changes from #103, merge that first.

The RPC test hangs and must be forcefully killed if the variable `count` is increased past `1` where the retrieved document size surpasses the buffer size defined in `WsTx.DefaultBufferSize`.

@ProphetLamb I have not been able to figure this one out yet, I'm hoping you might have some insights.

Some notes from my debugging:
The rest client works normally.
`System.Text.Json` has it's own `DefaultBufferSize` which also defaults to `16 * 1024`