### PR TITLE
Changed SimpleDeleteTest to use a query to select the deleted record.

### DIFF
--- a/tests/Driver.Tests/Queries/QueryTests.cs
+++ b/tests/Driver.Tests/Queries/QueryTests.cs
@@ -57,7 +57,9 @@ public abstract class QueryTests<T, TKey, TValue>
 
             TestHelper.AssertOk(deleteResponse);
 
-            var selectResponse = await db.Select(thing);
+            string sql = "SELECT * FROM $thing";
+            Dictionary<string, object?> param = new() { ["thing"] = thing, };
+            var selectResponse = await db.Query(sql, param);
             TestHelper.AssertOk(selectResponse);
             selectResponse.TryGetFirstValue(out ResultValue result).Should().BeTrue();
             result.Inner.ValueKind.Should().Be(JsonValueKind.Array);


### PR DESCRIPTION
Looks like the `Select` response for RPC has changed when it has no results and is no longer consistent with the Rest response.

So I switched it to a query which remains consistent.