### PR TITLE
Fix MultipleResultSetQueryTest

### DIFF
--- a/src/Common/StringHelper.cs
+++ b/src/Common/StringHelper.cs
@@ -1,0 +1,31 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+
+namespace SurrealDB.Common;
+
+internal static class StringHelper {
+    public static char End(this string str, int offset = 1) {
+        return str[str.Length - offset];
+    }
+    public static char End(this ReadOnlySpan<char> str, int offset = 1) {
+        return str[str.Length - offset];
+    }
+
+    public static bool IsEmpty([NotNullWhen(false)] this string? str) {
+        return String.IsNullOrEmpty(str);
+    }
+
+    public static string Concat(ReadOnlySpan<char> p0, ReadOnlySpan<char> p1, ReadOnlySpan<char> p2 = default, ReadOnlySpan<char> p3 = default) {
+#if NET5_0_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+        return String.Concat(p0, p1, p2, p3);
+#else
+        int cap = p0.Length + p1.Length + p2.Length + p3.Length;
+        ValueStringBuilder sb = cap <= 512 ? new(stackalloc char[cap]) : new(cap);
+        sb.Append(p0);
+        sb.Append(p1);
+        sb.Append(p2);
+        sb.Append(p3);
+        return sb.ToString();
+#endif
+    }
+}

--- a/src/Common/ValueStringBuilder.cs
+++ b/src/Common/ValueStringBuilder.cs
@@ -99,6 +99,9 @@ internal ref struct ValueStringBuilder
     /// <summary>Returns the underlying storage of the builder.</summary>
     public Span<char> RawChars => _chars;
 
+    /// <summary>Indicates whether the represented string is empty.</summary>
+    public bool IsEmpty => 0 >= (uint)Length;
+
     /// <summary>
     /// Returns a span around the contents of the builder.
     /// </summary>

--- a/src/Models/Result/ResponseExtensions.cs
+++ b/src/Models/Result/ResponseExtensions.cs
@@ -5,20 +5,18 @@ using SurrealDB.Common;
 namespace SurrealDB.Models.Result;
 
 public static class ResponseExtensions {
-    public static bool TryGetFirstError(in this Result.DriverResponse rsp, out ErrorResult result) {
-        foreach (ErrorResult res in rsp.Errors) {
-            result = res;
-            return true;
-        }
-
-        result = default;
-        return false;
+    public static bool TryGetFirstError(in this DriverResponse rsp, out ErrorResult result) {
+        var en = rsp.Errors;
+        bool success = en.MoveNext();
+        result = success ? en.Current : default;
+        en.Dispose();
+        return success;
     }
 
-    public static ErrorResult FirstError(in this Result.DriverResponse rsp) => rsp.TryGetFirstError(out var err) ? err : ResultContentException.ExpectedAnyError();
-    public static ErrorResult FirstError(in this Result.DriverResponse rsp, in ErrorResult fallback) => rsp.TryGetFirstError(out var err) ? err : fallback;
+    public static ErrorResult FirstError(in this DriverResponse rsp) => rsp.TryGetFirstError(out var err) ? err : ResultContentException.ExpectedAnyError();
+    public static ErrorResult FirstError(in this DriverResponse rsp, in ErrorResult fallback) => rsp.TryGetFirstError(out var err) ? err : fallback;
 
-    public static bool TryGetFirstValue(in this Result.DriverResponse rsp, out ResultValue result) {
+    public static bool TryGetFirstValue(in this DriverResponse rsp, out ResultValue result) {
         foreach (OkResult res in rsp.Oks) {
             if (res.Value.Inner.ValueKind is not JsonValueKind.Undefined) {
                 result = res.Value;
@@ -30,25 +28,25 @@ public static class ResponseExtensions {
         return false;
     }
 
-    public static ResultValue FirstValue(in this Result.DriverResponse rsp) => rsp.TryGetFirstValue(out var err) ? err : ResultContentException.ExpectedAnyOk().Value;
+    public static ResultValue FirstValue(in this DriverResponse rsp) => rsp.TryGetFirstValue(out var err) ? err : ResultContentException.ExpectedAnyOk().Value;
 
-    public static ResultValue FirstValue(in this Result.DriverResponse rsp, in ResultValue fallback) => rsp.TryGetFirstValue(out var err) ? err : fallback;
+    public static ResultValue FirstValue(in this DriverResponse rsp, in ResultValue fallback) => rsp.TryGetFirstValue(out var err) ? err : fallback;
 
-    public static bool TryGetSingleError(in this Result.DriverResponse rsp, out ErrorResult result) {
-        Result.DriverResponse.ErrorIterator en = rsp.Errors;
+    public static bool TryGetSingleError(in this DriverResponse rsp, out ErrorResult result) {
+        DriverResponse.ErrorIterator en = rsp.Errors;
         return SequenceHelper.TrySingle(ref en, out result);
     }
 
-    public static ErrorResult SingleError(in this Result.DriverResponse rsp) => rsp.TryGetSingleError(out var err) ? err : ResultContentException.ExpectedSingleError();
-    public static ErrorResult SingleError(in this Result.DriverResponse rsp, in ErrorResult fallback) => rsp.TryGetSingleError(out var err) ? err : fallback;
+    public static ErrorResult SingleError(in this DriverResponse rsp) => rsp.TryGetSingleError(out var err) ? err : ResultContentException.ExpectedSingleError();
+    public static ErrorResult SingleError(in this DriverResponse rsp, in ErrorResult fallback) => rsp.TryGetSingleError(out var err) ? err : fallback;
 
-    public static bool TryGetSingleValue(in this Result.DriverResponse rsp, out ResultValue result) {
-        Result.DriverResponse.OkIterator en = rsp.Oks;
+    public static bool TryGetSingleValue(in this DriverResponse rsp, out ResultValue result) {
+        DriverResponse.OkIterator en = rsp.Oks;
         bool success = SequenceHelper.TrySingle(ref en, out OkResult ok);
         result = ok.Value;
         return success;
     }
 
-    public static ResultValue SingleValue(in this Result.DriverResponse rsp) => rsp.TryGetSingleValue(out var err) ? err : ResultContentException.ExpectedSingleOk().Value;
-    public static ResultValue SingleValue(in this Result.DriverResponse rsp, in ResultValue fallback) => rsp.TryGetSingleValue(out var err) ? err : fallback;
+    public static ResultValue SingleValue(in this DriverResponse rsp) => rsp.TryGetSingleValue(out var err) ? err : ResultContentException.ExpectedSingleOk().Value;
+    public static ResultValue SingleValue(in this DriverResponse rsp, in ResultValue fallback) => rsp.TryGetSingleValue(out var err) ? err : fallback;
 }

--- a/src/Models/Result/ResponseExtensions.cs
+++ b/src/Models/Result/ResponseExtensions.cs
@@ -20,7 +20,7 @@ public static class ResponseExtensions {
 
     public static bool TryGetFirstValue(in this Result.DriverResponse rsp, out ResultValue result) {
         foreach (OkResult res in rsp.Oks) {
-            if (res.Value.Inner.ValueKind is not (JsonValueKind.Undefined or JsonValueKind.Null)) {
+            if (res.Value.Inner.ValueKind is not JsonValueKind.Undefined) {
                 result = res.Value;
                 return true;
             }

--- a/src/Models/Thing.cs
+++ b/src/Models/Thing.cs
@@ -25,10 +25,9 @@ public readonly record struct Thing {
     private readonly int _split;
     private readonly string _inner;
 
-    public Thing(string thing) {
-        _split = thing.IndexOf(CHAR_SEP);
-
-        _inner = thing;
+    public Thing(string? thing) {
+        _split = thing is null ? -1 : thing.IndexOf(CHAR_SEP);
+        _inner = thing ?? "";
     }
 
     public Thing(
@@ -48,7 +47,7 @@ public readonly record struct Thing {
             _inner = table;
             return;
         }
-        
+
         string keyStr = JsonSerializer.Serialize(key, SerializerOptions.Shared);
         if (keyStr[0] == '"' && keyStr[keyStr.Length - 1] == '"') {
             // This key is being represented in JSON as a string (rather than a number, object or array)
@@ -56,10 +55,10 @@ public readonly record struct Thing {
             keyStr = keyStr.Substring(1, keyStr.Length - 2);
             keyStr = EscapeComplexCharactersIfRequired(keyStr);
         }
-        
+
         _inner = $"{table}{CHAR_SEP}{keyStr}";
     }
-    
+
     /// <summary>
     /// Returns the Table part of the Thing
     /// </summary>
@@ -105,7 +104,7 @@ public readonly record struct Thing {
 
         return key[0] == CHAR_PRE && key[key.Length - 1] == CHAR_SUF;
     }
-    
+
     private static string EscapeKey(in ReadOnlySpan<char> key) {
         return $"{CHAR_PRE}{key.ToString()}{CHAR_SUF}";
     }
@@ -141,13 +140,13 @@ public readonly record struct Thing {
             return true;
         }
     }
-    
+
     [Pure]
     private bool GetKeyOffset(out int offset) {
         offset = _split + 1;
         return HasKey;
     }
-    
+
     public static implicit operator Thing(in string? thing) {
         if (thing == null) {
             return default;
@@ -194,11 +193,11 @@ public readonly record struct Thing {
 
     public sealed class ThingConverter : JsonConverter<Thing> {
         public override Thing Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
-            return new (reader.GetString());
+            return new(reader.GetString());
         }
 
         public override Thing ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
-            return new (reader.GetString());
+            return new(reader.GetString());
         }
 
         public override void Write(Utf8JsonWriter writer, Thing value, JsonSerializerOptions options) {

--- a/src/Models/ThingHelper.cs
+++ b/src/Models/ThingHelper.cs
@@ -1,0 +1,202 @@
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+
+using SurrealDB.Common;
+using SurrealDB.Json;
+
+namespace SurrealDB.Models;
+
+public static class ThingExtensions {
+    public static Thing ToThing<T>(in this (string Table, T Key) thing) {
+        return Thing.From(thing.Table, thing.Key);
+    }
+
+    public static string ToUri(in this Thing thing) {
+        var (table, key) = thing;
+        return (!table.IsEmpty, thing.HasKey) switch {
+            (true, true) => StringHelper.Concat(table, "/", UriEscapeKey(key)),
+            (true, false) => table.ToString(),
+            (false, true) => StringHelper.Concat("/", UriEscapeKey(key)),
+            (false, false) => thing.TableAndKey ?? ""
+        };
+    }
+
+    private static string UriEscapeKey(ReadOnlySpan<char> key) {
+        return Uri.EscapeDataString(ThingHelper.IsEscaped(key) ? ThingHelper.UnescapeKey(key) : key.ToString());
+    }
+}
+
+internal static class ThingHelper {
+    public const char SEPARATOR = ':';
+    public const char PREFIX = '⟨';
+    public const char SUFFIX = '⟩';
+    public const string ESC_SUFFIX = @"\⟩";
+
+    public static string SerializeKey<T>(in T key) {
+        if (IsStringableType(in key)) {
+            // the ToString method is cheap
+            var text = key.ToString();
+            return RequiresEscape(text) ? EscapeKey(text) : text;
+        }
+
+        var json = JsonSerializer.Serialize(key, SerializerOptions.Shared);
+        // string literals may require escaping
+        if (TryGetJsonString(json, out ReadOnlySpan<char> literal)) {
+            return RequiresEscape(literal) ? EscapeKey(literal) : literal.ToString();
+        }
+        // objects and arrays do not
+        return json;
+    }
+
+    public static bool IsStringableType<T>([NotNullWhen(true)] in T value) {
+        var t = typeof(T);
+        if (value is not null && t == typeof(object)) {
+            t = value.GetType();
+        }
+        // decimal is no primitive
+        return t == typeof(string) || t == typeof(ReadOnlyMemory<char>);
+    }
+
+    public static bool IsEscaped(ReadOnlySpan<char> key) {
+        return key.Length >= 2 && key[0] == PREFIX && key.End() == SUFFIX;
+    }
+
+    public static string EscapeKey(ReadOnlySpan<char> key) {
+        Debug.Assert(key.Length > 0);
+        int cap = key.Length + 2;
+        ValueStringBuilder sb = cap <= 512 ? new(stackalloc char[cap]) : new(cap);
+        sb.Append(PREFIX);
+        for (int p = 0; p < key.Length; p++) {
+            if (key[p] == SUFFIX) {
+                return EscapeKeyInternal(key, p, ref sb);
+            }
+        }
+        sb.Append(key);
+        sb.Append(SUFFIX);
+        return sb.ToString();
+    }
+
+    private static string EscapeKeyInternal(ReadOnlySpan<char> key, int pos, ref ValueStringBuilder sb) {
+        sb.Append(key.Slice(0, pos));
+        sb.Append(ESC_SUFFIX);
+        pos += 1;
+        while (pos < key.Length) {
+            int cur = pos;
+            while (cur < key.Length) {
+                if (key[cur] != SUFFIX) {
+                    cur += 1;
+                    continue;
+                }
+                break;
+            }
+            sb.Append(key.Slice(pos, cur - pos));
+            sb.Append(ESC_SUFFIX);
+            pos = cur + 1;
+        }
+        sb.Append(SUFFIX);
+        return sb.ToString();
+    }
+
+    public static bool RequiresEscape(ReadOnlySpan<char> key) {
+        return !IsEscaped(key) && ContainsComplexCharacters(key);
+    }
+
+    private static bool ContainsComplexCharacters(ReadOnlySpan<char> key) {
+        foreach (char c in key) {
+            if (IsComplexCharacter(c)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsComplexCharacter(char c) {
+        // A complex character is one that is not 0..9, a..Z or _
+        switch (c) {
+            // case >= '*' and <= '/':
+            case >= '0' and <= '9':
+            case >= 'a' and <= 'z':
+            case >= 'A' and <= 'Z':
+            case '_':
+                return false;
+            default:
+                return true;
+        }
+    }
+
+    public static string UnescapeKey(ReadOnlySpan<char> key) {
+        if (key.IsEmpty) {
+            return "";
+        }
+
+        if (key[0] != PREFIX | key.End() != SUFFIX) {
+            return key.ToString();
+        }
+        Debug.Assert(key.Length >= 2);
+
+        int last = key.Length - 1;
+        for (int p = 0; p < last; p++) {
+            if (key.Slice(p, ESC_SUFFIX.Length) == ESC_SUFFIX) {
+                // found escape sequence, unescape
+                return UnescapeKeyInternal(key, p);
+            }
+        }
+
+        // only strip prefix and suffix
+        return key.Slice(1, key.Length - 2).ToString();
+    }
+
+    private static string UnescapeKeyInternal(ReadOnlySpan<char> key, int pos) {
+        Debug.Assert(key.Slice(pos, ESC_SUFFIX.Length) == ESC_SUFFIX);
+        ValueStringBuilder sb = key.Length <= 512 ? new(stackalloc char[key.Length]) : new(key.Length);
+
+        sb.Append(key.Slice(0, pos));
+        sb.Append(SUFFIX);
+
+        int last = key.Length - 1;
+        while (pos < key.Length) {
+            int cur = pos;
+            while (cur < last) {
+                if (key.Slice(cur, ESC_SUFFIX.Length) != ESC_SUFFIX) {
+                    cur += 1;
+                    continue;
+                }
+                break;
+            }
+
+            if (cur == last && key.Slice(cur, ESC_SUFFIX.Length) != ESC_SUFFIX) {
+                // loop exited at end and the end is not \⟩
+                // append whatever end inclusive
+                cur += ESC_SUFFIX.Length;
+                sb.Append(key.Slice(pos, cur - pos));
+            } else {
+                sb.Append(key.Slice(pos, cur - pos));
+                sb.Append(SUFFIX);
+            }
+
+            pos = cur;
+        }
+
+        return sb.ToString();
+    }
+
+    public static bool TryGetJsonString(ReadOnlySpan<char> text, out ReadOnlySpan<char> literal) {
+        if (2 >= (uint)text.Length) {
+            literal = text;
+            return false;
+        }
+        char start = text[0], end = text.End();
+        if (start == '"' & end == '"') {
+            literal = text.Slice(1, text.Length - 2);
+            return true; // string strip quotes
+        }
+
+        literal = text;
+        return false;
+    }
+}

--- a/tests/Core.Tests/ThingTests.cs
+++ b/tests/Core.Tests/ThingTests.cs
@@ -69,7 +69,7 @@ public class ThingTests {
     public void TableStringNoKeyThing() {
         var table = "TableName";
 
-        var thing = new Thing(table);
+        Thing thing = table;
         Logger.WriteLine("Thing: {0}", thing);
 
         thing.ToString().Should().BeEquivalentTo(table);
@@ -87,7 +87,7 @@ public class ThingTests {
         var table = "TableName";
         var expectedThing = $"{table}:{key}";
 
-        var thing = new Thing(table, key);
+        Thing thing = (table, key);
         Logger.WriteLine("Thing: {0}", thing);
 
         thing.ToString().Should().BeEquivalentTo(expectedThing);
@@ -105,7 +105,7 @@ public class ThingTests {
         var table = "TableName";
         var expectedThing = $"{table}:{key}";
 
-        var thing = new Thing(expectedThing);
+        Thing thing = expectedThing;
         Logger.WriteLine("Thing: {0}", thing);
 
         thing.ToString().Should().BeEquivalentTo(expectedThing);
@@ -121,10 +121,10 @@ public class ThingTests {
     [MemberData(nameof(ComplexStringKeys))]
     public void TableAndStringKeyWithComplexCharacterThing(string key) {
         var table = "TableName";
-        var escapedKey = $"{Thing.CHAR_PRE}{key}{Thing.CHAR_SUF}";
+        var escapedKey = $"{ThingHelper.PREFIX}{key}{ThingHelper.SUFFIX}";
         var expectedThing = $"{table}:{escapedKey}";
 
-        var thing = new Thing(table, key);
+        var thing = Thing.From(table, key);
         Logger.WriteLine("Thing: {0}", thing);
 
         thing.ToString().Should().BeEquivalentTo(expectedThing);
@@ -140,10 +140,10 @@ public class ThingTests {
     [MemberData(nameof(ComplexStringKeys))]
     public void TableAndStringKeyAlreadyEscapedThing(string key) {
         var table = "TableName";
-        var escapedKey = $"{Thing.CHAR_PRE}{key}{Thing.CHAR_SUF}";
+        var escapedKey = $"{ThingHelper.PREFIX}{key}{ThingHelper.SUFFIX}";
         var expectedThing = $"{table}:{escapedKey}";
 
-        var thing = new Thing(table, escapedKey);
+        var thing = Thing.From(table, escapedKey);
         Logger.WriteLine("Thing: {0}", thing);
 
         thing.ToString().Should().BeEquivalentTo(expectedThing);
@@ -161,7 +161,7 @@ public class ThingTests {
         var table = "TableName";
         var expectedThing = $"{table}:{key}";
 
-        var thing = new Thing(table, key);
+        var thing = Thing.From(table, key);
         Logger.WriteLine("Thing: {0} ({1})", thing, type);
 
         thing.ToString().Should().BeEquivalentTo(expectedThing);
@@ -177,10 +177,10 @@ public class ThingTests {
     [MemberData(nameof(ObjectKeys))]
     public void TableAndObjectKeyThing(object key, string unescapedKey, bool shouldBeEscaped, Type type) {
         var table = "TableName";
-        string expectedKey = shouldBeEscaped ? $"{Thing.CHAR_PRE}{unescapedKey}{Thing.CHAR_SUF}" : unescapedKey;
-        string expectedThing = $"{table}{Thing.CHAR_SEP}{expectedKey}";
+        string expectedKey = shouldBeEscaped ? $"{ThingHelper.PREFIX}{unescapedKey}{ThingHelper.SUFFIX}" : unescapedKey;
+        string expectedThing = $"{table}{ThingHelper.SEPARATOR}{expectedKey}";
 
-        var thing = new Thing(table, key);
+        var thing = (table, key).ToThing();
         Logger.WriteLine("Thing: {0} ({1})", thing, type);
 
         thing.ToString().Should().BeEquivalentTo(expectedThing);
@@ -193,19 +193,12 @@ public class ThingTests {
     }
 
     [Fact]
-    public void NullEqualsDefaultThing() {
-        Thing nullThing = new(null);
-        Thing defaultThing = default;
-        defaultThing.Should().BeEquivalentTo(nullThing);
-    }
-
-    [Fact]
     public void NullThingPropertyAccessors() {
         Thing t = default;
+        t.HasKey.Should().BeFalse();
         t.Table.ToString().Should().BeEmpty();
         t.TableAndSeparator.ToString().Should().BeEmpty();
         t.Key.ToString().Should().BeEmpty();
-        t.HasKey.Should().BeFalse();
     }
 
     [Fact]
@@ -213,7 +206,7 @@ public class ThingTests {
         Thing t = default;
         var json = JsonSerializer.Serialize(t, SerializerOptions.Shared);
         json.Should().Be("\"\"");
-        Thing empty = new("");
+        Thing empty = "";
         var emptyJson = JsonSerializer.Serialize(empty, SerializerOptions.Shared);
         emptyJson.Should().BeEquivalentTo(json);
     }

--- a/tests/Core.Tests/ThingTests.cs
+++ b/tests/Core.Tests/ThingTests.cs
@@ -191,4 +191,30 @@ public class ThingTests {
         thing.HasKey.Should().BeTrue();
         thing.ToUri().Should().BeEquivalentTo($"{table}/{Uri.EscapeDataString(unescapedKey)}");
     }
+
+    [Fact]
+    public void NullEqualsDefaultThing() {
+        Thing nullThing = new(null);
+        Thing defaultThing = default;
+        defaultThing.Should().BeEquivalentTo(nullThing);
+    }
+
+    [Fact]
+    public void NullThingPropertyAccessors() {
+        Thing t = default;
+        t.Table.ToString().Should().BeEmpty();
+        t.TableAndSeparator.ToString().Should().BeEmpty();
+        t.Key.ToString().Should().BeEmpty();
+        t.HasKey.Should().BeFalse();
+    }
+
+    [Fact]
+    public void NullThingSerialized() {
+        Thing t = default;
+        var json = JsonSerializer.Serialize(t, SerializerOptions.Shared);
+        json.Should().Be("\"\"");
+        Thing empty = new("");
+        var emptyJson = JsonSerializer.Serialize(empty, SerializerOptions.Shared);
+        emptyJson.Should().BeEquivalentTo(json);
+    }
 }

--- a/tests/Core.Tests/ThingTests.cs
+++ b/tests/Core.Tests/ThingTests.cs
@@ -64,14 +64,14 @@ public class ThingTests {
     public static List<object[]> ComplexStringKeys => Keys.SelectMany(s => ComplexChars.Select(c => string.Format(s, c))).Select(e => new object[]{e}).ToList();
     public static List<object[]> NumberKeys => Numbers.Select(e => new []{e, e.GetType()}).ToList();
     public static List<object[]> ObjectKeys => Objects.Select(e => new []{e.key, e.expectedKey, e.shouldBeEscaped, e.key.GetType()}).ToList();
-    
+
     [Fact]
     public void TableStringNoKeyThing() {
         var table = "TableName";
 
         var thing = new Thing(table);
         Logger.WriteLine("Thing: {0}", thing);
-        
+
         thing.ToString().Should().BeEquivalentTo(table);
         thing.Table.ToString().Should().BeEquivalentTo(table);
         thing.TableAndSeparator.ToString().Should().BeEquivalentTo(table);
@@ -80,7 +80,7 @@ public class ThingTests {
         thing.HasKey.Should().BeFalse();
         thing.ToUri().Should().BeEquivalentTo(table);
     }
-    
+
     [Theory]
     [MemberData(nameof(StandardStringKeys))]
     public void TableAndStringKeyThing(string key) {
@@ -89,7 +89,7 @@ public class ThingTests {
 
         var thing = new Thing(table, key);
         Logger.WriteLine("Thing: {0}", thing);
-        
+
         thing.ToString().Should().BeEquivalentTo(expectedThing);
         thing.Table.ToString().Should().BeEquivalentTo(table);
         thing.TableAndSeparator.ToString().Should().BeEquivalentTo($"{table}:");
@@ -98,7 +98,7 @@ public class ThingTests {
         thing.HasKey.Should().BeTrue();
         thing.ToUri().Should().BeEquivalentTo($"{table}/{Uri.EscapeDataString(key)}");
     }
-    
+
     [Theory]
     [MemberData(nameof(StandardStringKeys))]
     public void TableAndStringKeyFromStringThing(string key) {
@@ -116,7 +116,7 @@ public class ThingTests {
         thing.HasKey.Should().BeTrue();
         thing.ToUri().Should().BeEquivalentTo($"{table}/{Uri.EscapeDataString(key)}");
     }
-    
+
     [Theory]
     [MemberData(nameof(ComplexStringKeys))]
     public void TableAndStringKeyWithComplexCharacterThing(string key) {
@@ -135,7 +135,7 @@ public class ThingTests {
         thing.HasKey.Should().BeTrue();
         thing.ToUri().Should().BeEquivalentTo($"{table}/{Uri.EscapeDataString(key)}");
     }
-    
+
     [Theory]
     [MemberData(nameof(ComplexStringKeys))]
     public void TableAndStringKeyAlreadyEscapedThing(string key) {
@@ -145,7 +145,7 @@ public class ThingTests {
 
         var thing = new Thing(table, escapedKey);
         Logger.WriteLine("Thing: {0}", thing);
-        
+
         thing.ToString().Should().BeEquivalentTo(expectedThing);
         thing.Table.ToString().Should().BeEquivalentTo(table);
         thing.TableAndSeparator.ToString().Should().BeEquivalentTo($"{table}:");
@@ -154,7 +154,7 @@ public class ThingTests {
         thing.HasKey.Should().BeTrue();
         thing.ToUri().Should().BeEquivalentTo($"{table}/{Uri.EscapeDataString(key)}");
     }
-    
+
     [Theory]
     [MemberData(nameof(NumberKeys))]
     public void TableAndNumberKeyThing(object key, Type type) {
@@ -163,16 +163,16 @@ public class ThingTests {
 
         var thing = new Thing(table, key);
         Logger.WriteLine("Thing: {0} ({1})", thing, type);
-        
+
         thing.ToString().Should().BeEquivalentTo(expectedThing);
         thing.Table.ToString().Should().BeEquivalentTo(table);
         thing.TableAndSeparator.ToString().Should().BeEquivalentTo($"{table}:");
         thing.Key.ToString().Should().BeEquivalentTo(key.ToString());
         thing.IsKeyEscaped.Should().BeFalse();
         thing.HasKey.Should().BeTrue();
-        thing.ToUri().Should().BeEquivalentTo($"{table}/{Uri.EscapeDataString(key.ToString())}");
+        thing.ToUri().Should().BeEquivalentTo($"{table}/{Uri.EscapeDataString(key.ToString()!)}");
     }
-    
+
     [Theory]
     [MemberData(nameof(ObjectKeys))]
     public void TableAndObjectKeyThing(object key, string unescapedKey, bool shouldBeEscaped, Type type) {
@@ -182,7 +182,7 @@ public class ThingTests {
 
         var thing = new Thing(table, key);
         Logger.WriteLine("Thing: {0} ({1})", thing, type);
-        
+
         thing.ToString().Should().BeEquivalentTo(expectedThing);
         thing.Table.ToString().Should().BeEquivalentTo(table);
         thing.TableAndSeparator.ToString().Should().BeEquivalentTo($"{table}:");

--- a/tests/Driver.Tests/DatabaseTests.cs
+++ b/tests/Driver.Tests/DatabaseTests.cs
@@ -24,7 +24,6 @@ public abstract class DatabaseTestDriver<T>
         var signInStatus = await db.Signin(new RootAuth(TestHelper.User, TestHelper.Pass));
 
         TestHelper.AssertOk(signInStatus);
-        //AssertOk(await db.Invalidate());
 
         (string id1, string id2) = ("id1", "id2");
         var res1 = await db.Create(
@@ -51,14 +50,14 @@ public abstract class DatabaseTestDriver<T>
 
         TestHelper.AssertOk(res2);
 
-        Thing thing2 = new("person", id2);
+        Thing thing2 = ("person", id2);
         TestHelper.AssertOk(await db.Update(thing2, new { Marketing = false, }));
 
         TestHelper.AssertOk(await db.Select(thing2));
 
         TestHelper.AssertOk(await db.Delete(thing2));
 
-        Thing thing1 = new("person", id1);
+        Thing thing1 = ("person", id1);
         TestHelper.AssertOk(
             await db.Change(
                 thing1,

--- a/tests/Driver.Tests/Queries/GeneralQueryTests.cs
+++ b/tests/Driver.Tests/Queries/GeneralQueryTests.cs
@@ -28,7 +28,7 @@ public abstract class GeneralQueryTests<T>
     public GeneralQueryTests(ITestOutputHelper logger) {
         Logger = logger;
     }
-    
+
     private static readonly List<Car> CarRecords = new List<Car> {
         new Car(
             Brand: "Car 1",
@@ -134,7 +134,7 @@ public abstract class GeneralQueryTests<T>
             doc.Should().BeEquivalentTo(expectedObject);
         }
     );
-    
+
     [Fact]
     public async Task ManuallyGeneratedObjectStructureQueryTest() => await DbHandle<T>.WithDatabase(
         async db => {
@@ -204,7 +204,7 @@ GROUP BY RegisteredCountry;";
         async db => {
             MathRequestDocument expectedObject = new() { f1 = 1, f2 = 1, };
             var expectedResult = new MathResultDocument { result = expectedObject.f1 + expectedObject.f2 };
-        Thing thing = new("object", ThreadRng.Shared.Next());
+        Thing thing = Thing.From("object", ThreadRng.Shared.Next());
         await db.Create(thing, expectedObject);
 
             string sql = "SELECT (f1 + f2) as result FROM $record";
@@ -224,7 +224,7 @@ GROUP BY RegisteredCountry;";
             MathRequestDocument expectedObject = new() { f1 = float.Epsilon, f2 = float.Epsilon, };
             var expectedResult = new MathResultDocument { result = expectedObject.f1 + expectedObject.f2 };
 
-            Thing thing = new("object", ThreadRng.Shared.Next());
+            Thing thing = Thing.From("object", ThreadRng.Shared.Next());
             await db.Create(thing, expectedObject);
 
             string sql = "SELECT (f1 + f2) as result FROM $record";
@@ -245,7 +245,7 @@ GROUP BY RegisteredCountry;";
             MathRequestDocument expectedObject = new() { f1 = float.MinValue, f2 = float.MaxValue, };
             var expectedResult = new MathResultDocument { result = expectedObject.f1 + expectedObject.f2 };
 
-            Thing thing = new("object", ThreadRng.Shared.Next());
+            Thing thing = Thing.From("object", ThreadRng.Shared.Next());
             await db.Create(thing, expectedObject);
 
             string sql = "SELECT (f1 + f2) as result FROM $record";
@@ -266,7 +266,7 @@ GROUP BY RegisteredCountry;";
             MathRequestDocument expectedObject = new() { f1 = float.MaxValue, f2 = float.MinValue, };
             var expectedResult = new MathResultDocument { result = expectedObject.f1 - expectedObject.f2 };
 
-            Thing thing = new("object", ThreadRng.Shared.Next());
+            Thing thing = Thing.From("object", ThreadRng.Shared.Next());
             await db.Create(thing, expectedObject);
 
             string sql = "SELECT (f1 - f2) as result FROM $record";
@@ -309,7 +309,7 @@ GROUP BY RegisteredCountry;";
         Logger.WriteLine($"Start {i} - Thread ID {Thread.CurrentThread.ManagedThreadId}");
 
         var expectedResult = new TestObject<int, int>(i, i);
-        Thing thing = new("object", expectedResult.Key);
+        Thing thing = Thing.From("object", expectedResult.Key);
 
         var createResponse = await db.Create(thing, expectedResult).ConfigureAwait(false);
         AssertResponse(createResponse, expectedResult);

--- a/tests/Driver.Tests/Queries/GeneralQueryTests.cs
+++ b/tests/Driver.Tests/Queries/GeneralQueryTests.cs
@@ -289,10 +289,13 @@ GROUP BY RegisteredCountry;";
             var response = await db.Query(sql, null);
 
             TestHelper.AssertOk(response);
-            ResultValue result = response.FirstValue();
-            string? doc = result.AsObject<string>();
-            doc.Should().NotBeNull();
-            doc.Should().Be(expectedResult);
+            // we execute two stmts, let and select.
+            // let should return null
+            response.Oks.First().Value.AsObject<object>().Should().BeNull();
+            // select should be array of one string
+            var res = response.Oks.Skip(1).First().Value.AsEnumerable<string>();
+            res.Count.Should().Be(1);
+            res.First().Should().Be(expectedResult);
         }
     );
 

--- a/tests/Driver.Tests/Queries/ManagementQueryTests.cs
+++ b/tests/Driver.Tests/Queries/ManagementQueryTests.cs
@@ -55,7 +55,7 @@ public abstract class ManagementQueryTests<T>
             TestObject<int, string> expectedOriginalObject = new(1, originalDbName);
             TestObject<int, string> expectedOtherObject = new(1, otherDbName);
 
-            Thing thing = new("object", expectedOriginalObject.Key);
+            Thing thing = ("object", expectedOriginalObject.Key).ToThing();
             await db.Create(thing, expectedOriginalObject);
 
             {
@@ -97,7 +97,7 @@ public abstract class ManagementQueryTests<T>
             TestObject<int, string> expectedOriginalObject = new(1, originalNsName);
             TestObject<int, string> expectedOtherObject = new(1, otherNsName);
 
-            Thing thing = new("object", expectedOriginalObject.Key);
+            Thing thing = ("object", expectedOriginalObject.Key).ToThing();
             await db.Create(thing, expectedOriginalObject);
 
             {

--- a/tests/Driver.Tests/Queries/QueryTests.cs
+++ b/tests/Driver.Tests/Queries/QueryTests.cs
@@ -19,7 +19,7 @@ public abstract class QueryTests<T, TKey, TValue>
         async db => {
             TestObject<TKey, TValue> expectedObject = new(key, value);
 
-            Thing thing = new("object", expectedObject.Key!);
+            Thing thing = ("object", expectedObject.Key!).ToThing();
             var response = await db.Create(thing, expectedObject);
 
             ResultValue result = response.FirstValue();
@@ -34,7 +34,7 @@ public abstract class QueryTests<T, TKey, TValue>
         async db => {
             TestObject<TKey, TValue> expectedObject = new(key, value);
 
-            Thing thing = new("object", expectedObject.Key!);
+            Thing thing = ("object", expectedObject.Key!).ToThing();
             await db.Create(thing, expectedObject);
             var response = await db.Select(thing);
 
@@ -51,7 +51,7 @@ public abstract class QueryTests<T, TKey, TValue>
         async db => {
             TestObject<TKey, TValue> expectedObject = new(key, value);
 
-            Thing thing = new("object", expectedObject.Key!);
+            Thing thing = ("object", expectedObject.Key!).ToThing();
             await db.Create(thing, expectedObject);
             var deleteResponse = await db.Delete(thing);
 
@@ -73,7 +73,7 @@ public abstract class QueryTests<T, TKey, TValue>
         async db => {
             TestObject<TKey, TValue> expectedObject = new(key, default(TValue)!);
 
-            Thing thing = new("object", expectedObject.Key!);
+            Thing thing = ("object", expectedObject.Key!).ToThing();
             await db.Create(thing, expectedObject);
             expectedObject.Value = value;
             var response = await db.Update(thing, expectedObject);
@@ -92,7 +92,7 @@ public abstract class QueryTests<T, TKey, TValue>
             TestObject<TKey, TValue> createdObject = new(key, default(TValue)!);
             ExtendedTestObject<TKey, TValue> expectedObject = new(key, value, value);
 
-            Thing thing = new("object", createdObject.Key!);
+            Thing thing = ("object", createdObject.Key!).ToThing();
             await db.Create(thing, createdObject);
             await db.Modify(thing, new[]{
                 Patch.Replace("/Value", value!),
@@ -132,7 +132,7 @@ public abstract class QueryTests<T, TKey, TValue>
             TestObject<TKey, TValue> createdObject = new(key, default(TValue)!);
             ExtendedTestObject<TKey, TValue> expectedObject = new(key, value, value);
 
-            Thing thing = new("object", createdObject.Key!);
+            Thing thing = ("object", createdObject.Key!).ToThing();
             await db.Create(thing, createdObject);
             var response = await db.Change(thing, new {  Value = value, MergeValue = value });
 
@@ -149,7 +149,7 @@ public abstract class QueryTests<T, TKey, TValue>
         async db => {
             TestObject<TKey, TValue> expectedObject = new(key, value);
 
-            Thing thing = new("object", expectedObject.Key!);
+            Thing thing = ("object", expectedObject.Key!).ToThing();
             await db.Create(thing, expectedObject);
             string sql = "SELECT * FROM $thing";
             Dictionary<string, object?> param = new() { ["thing"] = thing, };
@@ -169,7 +169,7 @@ public abstract class QueryTests<T, TKey, TValue>
         async db => {
             TestObject<TKey, TValue> expectedObject = new(key, value);
 
-            Thing thing = new("object", expectedObject.Key!);
+            Thing thing = ("object", expectedObject.Key!).ToThing();
             await db.Create(thing, expectedObject);
 
             string sql = "SELECT * FROM object WHERE id = $thing";
@@ -191,7 +191,7 @@ public abstract class QueryTests<T, TKey, TValue>
             TestObject<TKey, TValue> expectedObject = new(key, value);
             Logger.WriteLine("exp: {0}", Serialize(expectedObject));
 
-            Thing thing = new("object", expectedObject.Key!);
+            Thing thing = ("object", expectedObject.Key!).ToThing();
             await db.Create(thing, expectedObject);
 
             string sql = "SELECT * FROM object WHERE Value = $value";
@@ -214,10 +214,10 @@ public abstract class QueryTests<T, TKey, TValue>
         async db => {
             TestObject<TKey, TValue> expectedObject = new(key, value);
 
-            Thing thing1 = new("object1", expectedObject.Key!);
+            Thing thing1 = ("object1", expectedObject.Key!).ToThing();
             await db.Create(thing1, expectedObject);
 
-            Thing thing2 = new("object2", expectedObject.Key!);
+            Thing thing2 = ("object2", expectedObject.Key!).ToThing();
             await db.Create(thing2, expectedObject);
 
             var relateSql = "RELATE ($thing1)->hasOtherThing->($thing2)";

--- a/tests/Driver.Tests/Roundtrip/RoundTripTests.cs
+++ b/tests/Driver.Tests/Roundtrip/RoundTripTests.cs
@@ -117,7 +117,7 @@ public abstract class RoundTripTests<T>
         var returnedDocument = result.AsObject<RoundTripObject>();
         RoundTripObject.AssertAreEqual(document, returnedDocument);
     });
-    
+
     [Theory]
     [MemberData(nameof(Documents))]
     public async Task CreateManyAndQueryRoundTripTest(RoundTripObject document) => await DbHandle<T>.WithDatabase(
@@ -126,7 +126,7 @@ public abstract class RoundTripTests<T>
             Logger.WriteLine("Document size in bytes: {0} x {1}", JsonSerializer.Serialize(document, SerializerOptions.Shared).Length * sizeof(char), count);
 
             for (int i = 0; i < count; i++) {
-                Thing thing = new("object", ThreadRng.Shared.Next());
+                Thing thing = ("object", ThreadRng.Shared.Next()).ToThing();
                 await db.Create(thing, document);
             }
 

--- a/tests/Driver.Tests/Roundtrip/RoundTripTests.cs
+++ b/tests/Driver.Tests/Roundtrip/RoundTripTests.cs
@@ -53,7 +53,7 @@ public abstract class RoundTripTests<T>
         async db => {
             Logger.WriteLine("Document size in bytes: {0}", JsonSerializer.Serialize(document, SerializerOptions.Shared).Length * sizeof(char));
 
-            Thing thing = new("object", ThreadRng.Shared.Next());
+            Thing thing = ("object", ThreadRng.Shared.Next()).ToThing();
             var response = await db.Create(thing, document);
 
             TestHelper.AssertOk(response);
@@ -62,14 +62,14 @@ public abstract class RoundTripTests<T>
             RoundTripObject.AssertAreEqual(document, returnedDocument);
         }
     );
-    
+
     [Theory]
     [MemberData(nameof(Documents))]
     public async Task CreateAndSelectRoundTripTest(RoundTripObject document) => await DbHandle<T>.WithDatabase(
         async db => {
             Logger.WriteLine("Document size in bytes: {0}", JsonSerializer.Serialize(document, SerializerOptions.Shared).Length * sizeof(char));
 
-            Thing thing = new("object", ThreadRng.Shared.Next());
+            Thing thing = ("object", ThreadRng.Shared.Next()).ToThing();
             await db.Create(thing, document);
             var response = await db.Select(thing);
 
@@ -79,14 +79,14 @@ public abstract class RoundTripTests<T>
             RoundTripObject.AssertAreEqual(document, returnedDocument);
         }
     );
-    
+
     [Theory]
     [MemberData(nameof(Documents))]
     public async Task CreateAndQueryRoundTripTest(RoundTripObject document) => await DbHandle<T>.WithDatabase(
         async db => {
             Logger.WriteLine("Document size in bytes: {0}", JsonSerializer.Serialize(document, SerializerOptions.Shared).Length * sizeof(char));
 
-            Thing thing = new("object", ThreadRng.Shared.Next());
+            Thing thing = ("object", ThreadRng.Shared.Next()).ToThing();
             await db.Create(thing, document);
             string sql = $"SELECT * FROM \"{thing}\"";
             var response = await db.Query(sql, null);
@@ -98,13 +98,13 @@ public abstract class RoundTripTests<T>
             RoundTripObject.AssertAreEqual(document, returnedDocument);
         }
     );
-    
+
     [Theory]
     [MemberData(nameof(Documents))]
     public async Task CreateAndParameterizedQueryRoundTripTest(RoundTripObject document) => await DbHandle<T>.WithDatabase(async db => {
         Logger.WriteLine("Document size in bytes: {0}", JsonSerializer.Serialize(document, SerializerOptions.Shared).Length * sizeof(char));
 
-        Thing thing = new("object", ThreadRng.Shared.Next());
+        Thing thing = ("object", ThreadRng.Shared.Next()).ToThing();
         var rsp = await db.Create(thing, document);
         rsp.HasErrors.Should().BeFalse();
         string sql = "SELECT * FROM $thing";


### PR DESCRIPTION
**PR depends on #106**

The `MultipleResultSetQueryTest` executes two stmts, as such the driver should return two results.
- The first stmt let, doesn't return anything, therefore the result is `null`.
- The 2nd stmt select returns a set of strings with length one.
The testcase now reflects the query