### PR TITLE
DatabaseRest.FormatVarsSlow Add '$' to vars not in dictionary (For #114)

### DIFF
--- a/src/Driver/Rest/DatabaseRest.cs
+++ b/src/Driver/Rest/DatabaseRest.cs
@@ -329,6 +329,7 @@ public sealed class DatabaseRest : IDatabase {
             if (_vars.TryGetValue(varName, out object? varValue)) {
                 result.Append(ToJson(varValue));
             } else if (vars?.TryGetValue(varName, out varValue) == true) {
+                result.Append('$');
                 result.Append(ToJson(varValue));
             } else {
                 result.Append(template.AsSpan(start, i - start));


### PR DESCRIPTION
Fix for #114.
FormatVarsSlow now adds a '$' before variables that are not found in the variables dictionary.