### PR TITLE
Fixed AddSurrealDB extension

### DIFF
--- a/src/Extensions/Service/Extensions.cs
+++ b/src/Extensions/Service/Extensions.cs
@@ -8,9 +8,9 @@ using SurrealDB.Driver.Rpc;
 namespace SurrealDB.Extensions.Service;
 
 public static class Extensions {
-    public static IServiceCollection AddSurrealDB(this IServiceCollection services, Action<ConfigBuilder.Basic> configure) {
-        var builder = ConfigBuilder.Create();
-        configure(builder);
+    public static IServiceCollection AddSurrealDB(this IServiceCollection services, Func<ConfigBuilder.Basic, IConfigBuilder> configure) {
+        var basicBuilder = ConfigBuilder.Create();
+        var builder = configure(basicBuilder);
         Config config = builder.Build();
 
         services.AddOptions();


### PR DESCRIPTION
Explanation for fix: Currently when using AddSurrealDB for DI, it uses an Action and uses the ConfigBuilder.Basic config. However, when specifying the driver (Rest or Rpc) that config does not get used and nothing gets injected to the container as a result. This fix makes it use a Func instead of an Action (which does return the correct config) and that is then read.